### PR TITLE
Start to add `create-bet` command

### DIFF
--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -31,3 +31,4 @@ nostr-sdk = { version = "0.32.0", default-features = false, features = [
 ]}
 dlc-messages = { version = "0.5.0", features = ["use-serde"] }
 lightning = "0.0.121"
+bitcoin.workspace = true

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -32,3 +32,5 @@ nostr-sdk = { version = "0.32.0", default-features = false, features = [
 dlc-messages = { version = "0.5.0", features = ["use-serde"] }
 lightning = "0.0.121"
 bitcoin.workspace = true
+dlc = "0.5.0"
+sha2 = "0.10.8"

--- a/crates/cdk-cli/Cargo.toml
+++ b/crates/cdk-cli/Cargo.toml
@@ -29,3 +29,5 @@ nostr-sdk = { version = "0.32.0", default-features = false, features = [
     "nip04",
     "nip44"
 ]}
+dlc-messages = { version = "0.5.0", features = ["use-serde"] }
+lightning = "0.0.121"

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -66,6 +66,8 @@ enum Commands {
     Restore(sub_commands::restore::RestoreSubCommand),
     /// Update Mint Url
     UpdateMintUrl(sub_commands::update_mint_url::UpdateMintUrlSubCommand),
+    // Create Global DLC Offer
+    DLC(sub_commands::dlc::DLCSubCommand),
 }
 
 #[tokio::main]
@@ -183,5 +185,6 @@ async fn main() -> Result<()> {
         Commands::UpdateMintUrl(sub_command_args) => {
             sub_commands::update_mint_url::update_mint_url(wallets, sub_command_args).await
         }
+        Commands::DLC(sub_command_args) => sub_commands::dlc::dlc(sub_command_args).await,
     }
 }

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -16,8 +16,6 @@ use rand::Rng;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 
-
-
 mod sub_commands;
 
 const DEFAULT_WORK_DIR: &str = ".cdk-cli";

--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -16,6 +16,8 @@ use rand::Rng;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 
+
+
 mod sub_commands;
 
 const DEFAULT_WORK_DIR: &str = ".cdk-cli";

--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -3,9 +3,19 @@ use core::panic;
 use anyhow::{Error, Result};
 use clap::{Args, Subcommand};
 use dlc_messages::oracle_msgs::{EventDescriptor, OracleAnnouncement};
-use nostr_sdk::{bitcoin::{PrivateKey, XOnlyPublicKey}, secp256k1::{Secp256k1, SecretKey}, Client, EventId, Keys, PublicKey};
+
+use dlc::secp_utils::schnorrsig_compute_sig_point;
+use nostr_sdk::{
+    bitcoin::{PrivateKey, XOnlyPublicKey},
+    secp256k1::{self, SecretKey},
+    Client, EventId, Keys, PublicKey,
+};
 
 use bitcoin::secp256k1::KeyPair;
+
+use cdk::{dhke::hash_to_curve, secp256k1::{Message, PublicKey as cdkPublicKey, Secp256k1}};
+
+use sha2::{Digest, Sha256};
 
 pub mod nostr_events;
 pub mod utils;
@@ -18,11 +28,23 @@ pub struct DLCSubCommand {
     pub command: DLCCommands,
 }
 
-pub struct PayoutStructure{
-    public_payout_hash: [u8; 32], //paper says payout hash, nut says xonly_pubkey
-    weight: u8,
 
+pub struct PayoutStructure {
+    public_payout_hash: Vec<cdk::nuts::PublicKey>, //paper says payout hash, nut says xonly_pubkey, return value from hash_to_curve is cdk::nuts::PublicKey
+    weight: Vec<u8>,
 }
+
+impl PayoutStructure{
+    // verify there is a weight for each public key
+    pub async fn verify(&self) -> bool {
+        self.public_payout_hash.len() == self.weight.len()
+    }
+}
+pub struct Branch {
+    blinded_locking_point: cdk::nuts::PublicKey,
+    payout_structure: PayoutStructure,
+}
+
 
 #[derive(Subcommand)]
 pub enum DLCCommands {
@@ -48,37 +70,62 @@ pub struct UserBet {
     // What other data needs to be passed around to create the contract?
 
     // Timeout branch??
-
-    pub blinding_factor: KeyPair, 
+    pub blinding_factor: KeyPair,
     pub payout_strucures: Vec<PayoutStructure>,
     pub merkle_root_hash: [u8; 32],
-    pub ecash_note: u32,  //Option( vec!(ecash notes))  I dont know the struct for an ecash note
+    pub ecash_note: u32, //Option( vec!(ecash notes))  I dont know the struct for an ecash note
 
     pub timeout: u32,
 }
 
 impl UserBet {
-    pub async fn locking_points(&self) -> Vec<XOnlyPublicKey> {
+    pub async fn locking_points(&self) -> Vec<cdkPublicKey> {
         // oracle announcment.nonce + blinding_factor * G
-        let mut locking_points: Vec<XOnlyPublicKey> = Vec::new();
+        let mut locking_points: Vec<cdkPublicKey> = Vec::new();
         let oracle_public_key = self.oracle_announcement.oracle_public_key;
 
         let nonce = self.oracle_announcement.oracle_event.oracle_nonces[0];
 
         match &self.oracle_announcement.oracle_event.event_descriptor {
             EventDescriptor::EnumEvent(event) => {
-                for outcome in &event.outcomes{
-                    let message = outcome;
+                for outcome in &event.outcomes {
+                    let mut hasher = Sha256::new();
+                    hasher.update(outcome.as_bytes());
+                    let result = hasher.finalize();
+                    let message = Message::from_slice(&result).expect("error caclulating message");
+                    
+                    //https://adiabat.github.io/dlc.pdf
+                    // https://github.com/p2pderivatives/rust-dlc/blob/master/dlc/src/secp_utils.rs
                     // let sG = R - h(m, R)A
                     // let sG = Nonce point - sha256(message || nonce) * OraclePubKey
                     // lockingpoints.push(sG)
                     // s is what the oracle posts in the attestation message so user can spend coins
+                    let secp = Secp256k1::new();
+                    let sig_point =
+                        schnorrsig_compute_sig_point(&secp, &oracle_public_key, &nonce, &message)
+                            .expect("error calculating signature point");
+                    locking_points.push(sig_point);
                 }
-            },
+            }
             EventDescriptor::DigitDecompositionEvent(_) => todo!(),
         }
         locking_points
-        
+    }
+
+    // Todo create blinded locking points and payout branches from them.
+
+    pub async fn timeout_branch(&self) -> Branch {
+        let timeout_hash = hash_to_curve(&self.timeout.to_be_bytes()).expect("error calculating timeout hash");
+
+        let payout_structure = PayoutStructure {
+            public_payout_hash: vec!(cdk::nuts::PublicKey::from_slice(&[0; 32]).unwrap()), 
+            weight: vec!(1),
+        };
+
+        Branch {
+            blinded_locking_point: timeout_hash,
+            payout_structure,
+        }
     }
 }
 

--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -1,0 +1,141 @@
+use core::panic;
+
+use anyhow::{Error, Result};
+use clap::{Args, Subcommand};
+use dlc_messages::oracle_msgs::{EventDescriptor, OracleAnnouncement};
+use nostr_sdk::{Client, EventId, Keys, PublicKey};
+
+pub mod nostr_events;
+pub mod utils;
+
+const RELAYS: [&str; 1] = ["wss://relay.damus.io"];
+
+#[derive(Args)]
+pub struct DLCSubCommand {
+    #[command(subcommand)]
+    pub command: DLCCommands,
+}
+
+#[derive(Subcommand)]
+pub enum DLCCommands {
+    CreateBet {
+        key: String,
+        oracle_event_id: String,
+        counterparty_pubkey: String,
+    },
+    // AcceptBet {
+    //     // the event id of the offered bet
+    //     event_id: String,
+    // },
+}
+
+// I imagine this is what will be sent back and forth in the kind 8888 messages
+pub struct UserBet {
+    pub id: i32,
+    pub oracle_announcement: String,
+    oracle_event_id: String,
+    user_outcomes: Vec<String>,
+    // blinding factor used to create blinded outcome locking points
+    // user_a dlc funding proofs
+    // What other data needs to be passed around to create the contract?
+}
+
+/// To manage DLC contracts (ie. creating and accepting bets)
+// TODO: Different name?
+pub struct DLC {
+    keys: Keys,
+    nostr: Client,
+}
+
+impl DLC {
+    /// Create new [`DLC`]
+    pub async fn new(keys: Keys) -> Result<Self, Error> {
+        let nostr = Client::new(&keys);
+        for relay in RELAYS.iter() {
+            nostr.add_relay(relay.to_string()).await?;
+        }
+        nostr.connect().await;
+
+        Ok(Self { keys, nostr })
+    }
+
+    /// Start a new DLC contract, and send to the counterparty
+    pub async fn create_bet(
+        &self,
+        announcement: OracleAnnouncement,
+        announcement_id: EventId,
+        counterparty_pubkey: nostr_sdk::key::PublicKey,
+        outcomes: Vec<String>,
+    ) -> Result<EventId, Error> {
+        // TODO: create blinded outcome locking points
+        // TODO: create dlc funding proofs
+
+        let msg = todo!("Create a user bet message and serialize it");
+
+        let offer_dlc_event =
+            nostr_events::create_dlc_msg_event(&self.keys, msg, &counterparty_pubkey)?;
+
+        match self.nostr.send_event(offer_dlc_event).await {
+            Ok(event_id) => Ok(event_id),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+
+    pub async fn accept_bet(&self, event_id: EventId) -> Result<EventId, Error> {
+        todo!()
+    }
+}
+
+pub async fn dlc(sub_command_args: &DLCSubCommand) -> Result<()> {
+    //let keys =
+    //   Keys::parse("nsec15jldh0htg2qeeqmqd628js8386fu4xwpnuqddacc64gh0ezdum6qaw574p").unwrap();
+
+    match &sub_command_args.command {
+        DLCCommands::CreateBet {
+            key,
+            oracle_event_id,
+            counterparty_pubkey,
+        } => {
+            let keys = Keys::parse(key).unwrap();
+            let oracle_event_id = EventId::from_hex(oracle_event_id).unwrap();
+            let counterparty_pubkey = PublicKey::from_hex(counterparty_pubkey).unwrap();
+
+            let dlc = DLC::new(keys).await?;
+
+            let announcement_event =
+                match nostr_events::lookup_announcement_event(oracle_event_id, &dlc.nostr).await {
+                    Some(Ok(event)) => event,
+                    _ => panic!("Oracle announcement event not found"),
+                };
+
+            let oracle_announcement =
+                utils::oracle_announcement_from_str(&announcement_event.content);
+
+            println!(
+                "Oracle announcement event content: {:?}",
+                oracle_announcement
+            );
+
+            // // TODO: get the outcomes from the oracle announcement???
+            let outcomes = match oracle_announcement.oracle_event.event_descriptor {
+                EventDescriptor::EnumEvent(ref e) => e.outcomes.clone(),
+                EventDescriptor::DigitDecompositionEvent(_) => unreachable!(),
+            };
+
+            println!("Outcomes: {:?}", outcomes);
+
+            // let event_id = dlc
+            //     .create_bet(
+            //         oracle_announcement,
+            //         *oracle_event_id,
+            //         *counterparty_pubkey,
+            //         outcomes,
+            //     )
+            //     .await?;
+
+            // println!("Event {} sent to {}", event_id, counterparty_pubkey);
+        }
+        _ => todo!(),
+    }
+    Ok(())
+}

--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -16,6 +16,12 @@ pub struct DLCSubCommand {
     pub command: DLCCommands,
 }
 
+pub struct PayoutStructure{
+    public_payout_hash: PublicKey,
+    weight: u8,
+
+}
+
 #[derive(Subcommand)]
 pub enum DLCCommands {
     CreateBet {
@@ -38,6 +44,15 @@ pub struct UserBet {
     // blinding factor used to create blinded outcome locking points
     // user_a dlc funding proofs
     // What other data needs to be passed around to create the contract?
+
+    // Timeout branch??
+
+    pub blinding_factor: u128, 
+    pub payout_strucures: Vec<PayoutStructure>,
+    pub merkle_root_hash: [u8; 32],
+    pub ecash_note: u32,  //Option( vec!(ecash notes))  I dont know the struct for an ecash note
+
+
 }
 
 /// To manage DLC contracts (ie. creating and accepting bets)

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -1,0 +1,47 @@
+use std::vec;
+
+use nostr_sdk::event::builder::Error;
+use nostr_sdk::nips::nip04;
+use nostr_sdk::{base64, Client, Event, EventBuilder, EventId, Filter, Keys, Kind, PublicKey, Tag};
+
+/// Create Kind 8_888 event tagged with the counterparty pubkey
+///
+/// see https://github.com/nostr-protocol/nips/blob/9157321a224bca77b3472a19de72885af9d6a91d/88.md#kind8_888
+///
+/// # Arguments
+/// * `keys` - The Keys used to sign the event
+/// * `msg` - The dlc message
+/// * `counterparty_pubkey` - Public key to send this message to
+pub fn create_dlc_msg_event(
+    keys: &Keys,
+    msg: String,
+    counterparty_pubkey: &PublicKey,
+) -> Result<Event, Error> {
+    // The DLC message is first serialized in binary, and then encrypted with NIP04.
+    let content = base64::encode(msg);
+
+    let content: String =
+        nip04::encrypt(&keys.secret_key()?.clone(), counterparty_pubkey, content)?;
+
+    EventBuilder::new(
+        Kind::Custom(8888),
+        content,
+        vec![Tag::public_key(*counterparty_pubkey)],
+    )
+    .to_event(keys)
+}
+
+pub async fn lookup_announcement_event(
+    event_id: EventId,
+    client: &Client,
+) -> Option<Result<Event, Error>> {
+    let filter = Filter::new().id(event_id).kind(Kind::Custom(88));
+    let events = client
+        .get_events_of(vec![filter], None)
+        .await
+        .expect("get_events_of failed");
+    if events.is_empty() {
+        return None;
+    }
+    Some(Ok(events.first().unwrap().clone()))
+}

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -45,3 +45,25 @@ pub async fn lookup_announcement_event(
     }
     Some(Ok(events.first().unwrap().clone()))
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::{Client, EventId, Keys};
+
+    #[tokio::test]
+    async fn test_lookup_announcement_event() {
+        let announemtent_id =
+            EventId::from_hex("d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529")
+                .unwrap();
+
+        let client = Client::new(&Keys::generate());
+        let relay = "wss://relay.damus.io";
+        client.add_relay(relay.to_string()).await.unwrap();
+        client.connect().await;
+        let event = lookup_announcement_event(announemtent_id, &client)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.id, announemtent_id);
+    }
+}

--- a/crates/cdk-cli/src/sub_commands/dlc/utils.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/utils.rs
@@ -21,13 +21,30 @@ pub fn oracle_announcement_from_str(str: &str) -> OracleAnnouncement {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+    use cdk::secp256k1::schnorr::Signature;
+    use dlc_messages::oracle_msgs::EventDescriptor;
 
     const ANNOUNCEMENT: &str = "ypyyyX6pdZUM+OovHftxK9StImd8F7nxmr/eTeyR/5koOVVe/EaNw1MAeJm8LKDV1w74Fr+UJ+83bVP3ynNmjwKbtJr9eP5ie2Exmeod7kw4uNsuXcw6tqJF1FXH3fTF/dgiOwAByEOAEd95715DKrSLVdN/7cGtOlSRTQ0/LsW/p3BiVOdlpccA/dgGDAACBDEyMzQENDU2NwR0ZXN0";
 
     #[test]
     fn test_decode_oracle_announcement() {
         let announcement = oracle_announcement_from_str(ANNOUNCEMENT);
-        println!("{:?}", announcement);
+
+        assert_eq!(
+            announcement.announcement_signature,
+            Signature::from_str(&String::from("ca9cb2c97ea975950cf8ea2f1dfb712bd4ad22677c17b9f19abfde4dec91ff992839555efc468dc353007899bc2ca0d5d70ef816bf9427ef376d53f7ca73668f")).unwrap()
+        );
+
+        let descriptor = announcement.oracle_event.event_descriptor;
+
+        match descriptor {
+            EventDescriptor::EnumEvent(e) => {
+                assert_eq!(e.outcomes.len(), 2);
+            }
+            EventDescriptor::DigitDecompositionEvent(e) => unreachable!(),
+        }
     }
 }

--- a/crates/cdk-cli/src/sub_commands/dlc/utils.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/utils.rs
@@ -1,0 +1,33 @@
+use dlc_messages::oracle_msgs::OracleAnnouncement;
+use lightning::util::ser::Readable;
+use nostr_sdk::base64;
+use std::io::Cursor;
+
+fn decode_bytes(str: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    // match FromHex::from_hex(str) {
+    //     Ok(bytes) => Ok(bytes),
+    //     Err(_) => Ok(base64::decode(str)?),
+    // }
+    base64::decode(str)
+}
+
+/// Parses a string into an oracle announcement.
+pub fn oracle_announcement_from_str(str: &str) -> OracleAnnouncement {
+    let bytes = decode_bytes(str).expect("Could not decode oracle announcement string");
+    let mut cursor = Cursor::new(bytes);
+
+    OracleAnnouncement::read(&mut cursor).expect("Could not parse oracle announcement")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ANNOUNCEMENT: &str = "ypyyyX6pdZUM+OovHftxK9StImd8F7nxmr/eTeyR/5koOVVe/EaNw1MAeJm8LKDV1w74Fr+UJ+83bVP3ynNmjwKbtJr9eP5ie2Exmeod7kw4uNsuXcw6tqJF1FXH3fTF/dgiOwAByEOAEd95715DKrSLVdN/7cGtOlSRTQ0/LsW/p3BiVOdlpccA/dgGDAACBDEyMzQENDU2NwR0ZXN0";
+
+    #[test]
+    fn test_decode_oracle_announcement() {
+        let announcement = oracle_announcement_from_str(ANNOUNCEMENT);
+        println!("{:?}", announcement);
+    }
+}

--- a/crates/cdk-cli/src/sub_commands/dlc/utils.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/utils.rs
@@ -1,6 +1,8 @@
+use bitcoin::{PublicKey};
 use dlc_messages::oracle_msgs::OracleAnnouncement;
 use lightning::util::ser::Readable;
 use nostr_sdk::base64;
+use sha2::{Sha256, Digest};
 use std::io::Cursor;
 
 fn decode_bytes(str: &str) -> Result<Vec<u8>, base64::DecodeError> {
@@ -18,6 +20,9 @@ pub fn oracle_announcement_from_str(str: &str) -> OracleAnnouncement {
 
     OracleAnnouncement::read(&mut cursor).expect("Could not parse oracle announcement")
 }
+
+
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/cdk-cli/src/sub_commands/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/mod.rs
@@ -2,6 +2,7 @@ pub mod balance;
 pub mod burn;
 pub mod check_spent;
 pub mod decode_token;
+pub mod dlc;
 pub mod melt;
 pub mod mint;
 pub mod mint_info;


### PR DESCRIPTION
I moved some of the stuff we had in the cashu-dlcstr-rs project into the `cdk-cli` crate because it seems like it makes the most sense to just work out this `cdk` fork.

I put the core cli functionality into cdk-cli/dlc/mod.rs and started to implement `create-bet`

You can test with this oracle event id (the event ID of the kind 88 nostr event that has the oracle announcement in it) `d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529`.

That is also a valid priv and pubkey, so I've just been testing with this command:

```bash
cargo run -- dlc create-bet d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529 d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529 d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529
```

but will need to actually use two keypairs later.

I'm thinking that we can use the `UserBet` struct (based on same struct in note-duel) as the message that we put into the kind 8888 dlc message event. This struct will need to contain all of the information for Bob to finalize the dlc. 
