### PR TITLE
add `dlc delete-offers <pubkey>`

### DIFF
--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -47,6 +47,9 @@ pub enum DLCCommands {
     },
     ListOffers {
         key: String,
+    },
+    DeleteOffers {
+        key: String,
     }, // AcceptBet {
        //     // the event id of the offered bet
        //     event_id: String,
@@ -301,6 +304,15 @@ pub async fn dlc(sub_command_args: &DLCSubCommand) -> Result<()> {
             let dlc = DLC::new(keys.secret_key()?).await?;
 
             let bets = nostr_events::list_dlc_offers(&keys, &dlc.nostr).await;
+
+            println!("{:?}", bets);
+        }
+        DLCCommands::DeleteOffers { key } => {
+            let keys = Keys::parse(key).unwrap();
+
+            let dlc = DLC::new(keys.secret_key()?).await?;
+
+            let bets = nostr_events::delete_all_dlc_offers(&keys, &dlc.nostr).await;
 
             println!("{:?}", bets);
         }

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -77,6 +77,29 @@ pub async fn list_dlc_offers(keys: &Keys, client: &Client) -> Option<Vec<UserBet
     Some(offers)
 }
 
+// Used to reset the state of our offers on the relays in case we change types of UserBet
+pub async fn delete_all_dlc_offers(keys: &Keys, client: &Client) -> Option<Vec<EventId>> {
+    let filter = Filter::new()
+        .kind(Kind::Custom(8888))
+        .author(keys.public_key());
+    let events = client
+        .get_events_of(vec![filter], None)
+        .await
+        .expect("get_events_of failed");
+
+    if events.is_empty() {
+        return None;
+    }
+
+    let mut deleted: Vec<EventId> = Vec::new();
+
+    for event in events {
+        let id = client.delete_event(event.id).await.unwrap();
+        deleted.push(id);
+    }
+    Some(deleted)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
When we change the type of `UserBet`, then `dlc list-offers` panics because the encoded `UserBet` is of a different type. Maybe there is a better way to handle this, but for now you can use `dlc delete-offers <pubkey>` where `pubkey` is the pubkey of user that published the offers.

I added these keys to the bottom of our `sub_commands/dlc/mod.rs` file to use for testing:
```rust
// ALICE:
// - pub: d71b2434429b0f038ed35e0e3827bca5e65b6d44d1af9344f73b20ff7ffa93dd
// - priv: b9452287c9e4cf53cf935adbc2341931c68c19d8447fe571ccc8dd9b5ed85584
// BOB:
// - pub: b3e6ae1bdfa18106dafe4992b77149a38623662f78f5f60ee436e457f7965ee2
// - priv: 4e111131d31ad92ed5d37ab87d5046efa730f192f9c8f9b59f6c61caad1f8933

// anouncement_ID: d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529
```

So if Alice posts a dlc offer and then we change the `UserBet` type, you can fix it by running 

```bash
cargo run -- dlc delete-offers b9452287c9e4cf53cf935adbc2341931c68c19d8447fe571ccc8dd9b5ed85584
```

This should merge without conflicts if the timeout PR is merged too, otherwise lmk if you need me to resolve any conflicts