### PR TITLE
Update create bet

### DIFF
--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -337,7 +337,9 @@ mod tests {
     use nostr_sdk::{Client, EventId, Keys};
 
     use crate::sub_commands::dlc::{
-        nostr_events::{list_dlc_offers, lookup_announcement_event}, utils::oracle_announcement_from_str, DLC,
+        nostr_events::{delete_all_dlc_offers, list_dlc_offers, lookup_announcement_event},
+        utils::oracle_announcement_from_str,
+        DLC,
     };
 
     #[test]
@@ -386,10 +388,11 @@ mod tests {
 
         println!("{:?}", offers);
 
-        assert!(offers.len()>= 1);
-    }
+        assert!(offers.len() >= 1);
 
-    
+        /* clean up */
+        delete_all_dlc_offers(&keys, &client).await;
+    }
 }
 
 // ALICE:

--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -356,12 +356,8 @@ mod tests {
         let announcement_id =
             EventId::from_hex("d30e6c857a900ebefbf7dc3b678ead9215f4345476067e146ded973971286529")
                 .unwrap();
-        let keys = Keys::parse("4e111131d31ad92ed5d37ab87d5046efa730f192f9c8f9b59f6c61caad1f8933")
-            .unwrap();
-        let counterparty_keys = Keys::parse(
-            "b9452287c9e4cf53cf935adbc2341931c68c19d8447fe571ccc8dd9b5ed85584",
-        )
-        .unwrap();
+        let keys = Keys::generate();
+        let counterparty_keys = Keys::generate();
 
         let dlc = DLC::new(&keys.secret_key().unwrap()).await.unwrap();
 

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -169,6 +169,9 @@ mod tests {
         let offers = list_dlc_offers(&counterparty_privkey, &client).await.unwrap(); // error in line 74:58
 
         assert!(offers.len() >= 1);
+
+        /* clean up */
+        delete_all_dlc_offers(&keys, &client).await;
     }
 
     #[test]

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -161,7 +161,9 @@ mod tests {
 
         println!("event id: {:?}", event_id.to_hex());
 
-        let offers = list_dlc_offers(&counterparty_privkey, &client).await.unwrap(); // error in line 74:58
+        let offers = list_dlc_offers(&counterparty_privkey, &client)
+            .await
+            .unwrap(); // error in line 74:58
 
         assert!(offers.len() >= 1);
 
@@ -175,6 +177,5 @@ mod tests {
         let bet = serde_json::from_str::<UserBet>(str).unwrap();
 
         println!("{:?}", bet);
-        
     }
 }

--- a/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/nostr_events.rs
@@ -126,9 +126,7 @@ mod tests {
     fn test_create_dlc_message_event() {
         let keys = Keys::parse("4e111131d31ad92ed5d37ab87d5046efa730f192f9c8f9b59f6c61caad1f8933")
             .unwrap();
-        let counterparty_pubkey =
-            PublicKey::parse("d71b2434429b0f038ed35e0e3827bca5e65b6d44d1af9344f73b20ff7ffa93dd")
-                .unwrap();
+        let counterparty_pubkey = Keys::generate().public_key();
         let msg = String::from("hello");
 
         let msg = base64::encode(msg);
@@ -146,12 +144,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_dlc_offers() {
-        let keys = Keys::parse("4e111131d31ad92ed5d37ab87d5046efa730f192f9c8f9b59f6c61caad1f8933")
-            .unwrap();
-        let counterparty_privkey = Keys::parse("b9452287c9e4cf53cf935adbc2341931c68c19d8447fe571ccc8dd9b5ed85584").unwrap();
-        let counterparty_pubkey =
-            PublicKey::parse("d71b2434429b0f038ed35e0e3827bca5e65b6d44d1af9344f73b20ff7ffa93dd")
-                .unwrap();
+        let keys = Keys::generate();
+        let counterparty_privkey = Keys::generate();
+        let counterparty_pubkey = counterparty_privkey.public_key();
         let msg = String::from("hello");
         let msg = base64::encode(msg);
 

--- a/crates/cdk-cli/src/sub_commands/dlc/utils.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/utils.rs
@@ -32,6 +32,7 @@ mod tests {
     #[test]
     fn test_decode_oracle_announcement() {
         let announcement = oracle_announcement_from_str(ANNOUNCEMENT);
+        println!("{:?}", announcement);
 
         assert_eq!(
             announcement.announcement_signature,


### PR DESCRIPTION
I added an option for the user to pass the amount of the bet into the `create-bet` command.  And the also added the option so that the user could choose what outcome of the event he wanted to wager on.   Check the change on 169, It made sense to me to change `!=` to `<` but want to make sure you agree.