### PR TITLE
Sct funding proofs

### DIFF
--- a/crates/cdk-cli/src/main.rs
+++ b/crates/cdk-cli/src/main.rs
@@ -185,6 +185,6 @@ async fn main() -> Result<()> {
         Commands::UpdateMintUrl(sub_command_args) => {
             sub_commands::update_mint_url::update_mint_url(wallets, sub_command_args).await
         }
-        Commands::DLC(sub_command_args) => sub_commands::dlc::dlc(sub_command_args).await,
+        Commands::DLC(sub_command_args) => sub_commands::dlc::dlc(wallets, sub_command_args).await,
     }
 }

--- a/crates/cdk-cli/src/sub_commands/dlc/mod.rs
+++ b/crates/cdk-cli/src/sub_commands/dlc/mod.rs
@@ -1,12 +1,14 @@
 use core::panic;
 use std::collections::HashMap;
-use std::io::stdin;
+use std::io::{self, stdin, Write};
 use std::time::Duration;
 
 use anyhow::{Error, Result};
-use cdk::amount::Amount;
-use cdk::nuts;
+use cdk::amount::{Amount, SplitTarget};
 use cdk::nuts::nutdlc::{DLCLeaf, DLCRoot, DLCTimeoutLeaf, PayoutStructure};
+use cdk::nuts::{self, Conditions, SigFlag};
+use cdk::url::UncheckedUrl;
+use cdk::wallet::Wallet;
 use clap::{Args, Subcommand};
 use dlc::secp256k1_zkp::hashes::sha256;
 use dlc::{
@@ -27,6 +29,8 @@ use schnorr_fun::{fun::Scalar, Message, Schnorr};
 use serde::{Deserialize, Serialize};
 
 use sha2::Sha256;
+
+use super::balance::mint_balances;
 
 pub mod nostr_events;
 pub mod utils;
@@ -78,6 +82,7 @@ pub struct UserBet {
 
 /// To manage DLC contracts (ie. creating and accepting bets)
 // TODO: Different name?
+// TODO: put the wallet in here instead of passing it in every function
 pub struct DLC {
     keys: Keys,
     nostr: Client,
@@ -121,6 +126,55 @@ impl DLC {
             .encrypted_sign(&self.signing_keypair, &encryption_key, message)
     }
 
+    async fn create_funding_token(
+        &self,
+        wallet: &Wallet,
+        dlc_root: &DLCRoot,
+        amount: u64,
+    ) -> Result<()> {
+        let dlc_conditions = nuts::nut11::SpendingConditions::new_dlc(
+            &dlc_root,
+            Some(Conditions {
+                locktime: None,
+                pubkeys: None,
+                refund_keys: None,
+                num_sigs: None,
+                sig_flag: SigFlag::SigInputs, // TODO: figure out how to not inclue a sig_flag
+                threshold: Some(1),           // TOOD: this should come from payout structures
+            }),
+        );
+        let available_proofs = wallet.get_proofs().await?;
+
+        let include_fees = false;
+
+        let selected = wallet
+            .select_proofs_to_send(Amount::from(amount), available_proofs, include_fees)
+            .await
+            .unwrap();
+        let fundingProofs = wallet
+            .swap(
+                Some(Amount::from(amount)),
+                SplitTarget::default(),
+                selected,
+                Some(dlc_conditions),
+                include_fees,
+            )
+            .await?
+            .unwrap();
+
+        // TODO: encode this as a Token
+
+        println!(
+            "Funding proof secrets: {:?}",
+            fundingProofs
+                .iter()
+                .map(|p| p.secret.to_string())
+                .collect::<Vec<String>>()
+        );
+
+        Ok(())
+    }
+
     /// Start a new DLC contract, and send to the counterparty
     /// # Arguments
     /// * `announcement` - OracleAnnouncement
@@ -129,6 +183,7 @@ impl DLC {
     /// * `outcomes` - ??outcomes this user wants to bet on?? I think!
     pub async fn create_bet(
         &self,
+        wallet: &Wallet,
         announcement: OracleAnnouncement,
         announcement_id: EventId,
         counterparty_pubkey: nostr_sdk::key::PublicKey,
@@ -238,6 +293,10 @@ impl DLC {
             })
             .collect::<Result<_, Error>>()?;
 
+        // todo: include this in the offer
+        self.create_funding_token(&wallet, &dlc_root, amount)
+            .await?;
+
         let offer_dlc = UserBet {
             id: 7, // TODO,
             oracle_announcement: announcement.clone(),
@@ -270,7 +329,10 @@ impl DLC {
     }
 }
 
-pub async fn dlc(sub_command_args: &DLCSubCommand) -> Result<()> {
+pub async fn dlc(
+    wallets: HashMap<UncheckedUrl, Wallet>,
+    sub_command_args: &DLCSubCommand,
+) -> Result<()> {
     //let keys =
     //   Keys::parse("nsec15jldh0htg2qeeqmqd628js8386fu4xwpnuqddacc64gh0ezdum6qaw574p").unwrap();
 
@@ -328,8 +390,26 @@ pub async fn dlc(sub_command_args: &DLCSubCommand) -> Result<()> {
                 outcome_choice, amount
             );
 
+            /* let user pick which wallet to use */
+            let mints_amounts = mint_balances(wallets).await?;
+
+            println!("Enter a mint number to create a DLC offer for");
+
+            let mut user_input = String::new();
+            io::stdout().flush().unwrap();
+            stdin().read_line(&mut user_input)?;
+
+            let mint_number: usize = user_input.trim().parse()?;
+
+            if mint_number.gt(&(mints_amounts.len() - 1)) {
+                crate::bail!("Invalid mint number");
+            }
+
+            let wallet = mints_amounts[mint_number].0.clone();
+
             let event_id = dlc
                 .create_bet(
+                    &wallet,
                     oracle_announcement,
                     oracle_event_id,
                     counterparty_pubkey,
@@ -365,25 +445,86 @@ pub async fn dlc(sub_command_args: &DLCSubCommand) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use cdk::{amount::Amount, nuts::PublicKey};
-    use dlc_messages::oracle_msgs::{EventDescriptor, OracleAnnouncement};
+    use std::{collections::HashMap, fs, str::FromStr, sync::Arc};
+
+    use bip39::Mnemonic;
+    use cdk::{
+        cdk_database::{self, WalletDatabase},
+        url::UncheckedUrl,
+        wallet::Wallet,
+    };
+    use cdk_sqlite::WalletSqliteDatabase;
+    use dlc_messages::oracle_msgs::EventDescriptor;
     use nostr_sdk::{Client, EventId, Keys};
+    use rand::Rng;
 
     use crate::sub_commands::dlc::{
-        nostr_events::{delete_all_dlc_offers, list_dlc_offers, lookup_announcement_event},
+        nostr_events::{delete_all_dlc_offers, list_dlc_offers},
         utils::oracle_announcement_from_str,
         DLC,
     };
 
-    #[test]
-    fn generate_nostr_key() {
-        let keys = Keys::generate();
-        println!("{}", keys.public_key());
-        println!("{}", keys.secret_key().unwrap());
+    const DEFAULT_WORK_DIR: &str = ".cdk-cli";
+    const MINT_URL: &str = "http://localhost:3338";
+
+    /// helper function to initialize wallets
+    async fn initialize_wallets() -> HashMap<UncheckedUrl, Wallet> {
+        let work_dir = {
+            let home_dir = home::home_dir().unwrap();
+            home_dir.join(DEFAULT_WORK_DIR)
+        };
+        let localstore: Arc<dyn WalletDatabase<Err = cdk_database::Error> + Send + Sync> = {
+            let sql_path = work_dir.join("cdk-cli.sqlite");
+            let sql = WalletSqliteDatabase::new(&sql_path).await.unwrap();
+
+            sql.migrate().await;
+
+            Arc::new(sql)
+        };
+
+        let seed_path = work_dir.join("seed");
+
+        let mnemonic = match fs::metadata(seed_path.clone()) {
+            Ok(_) => {
+                let contents = fs::read_to_string(seed_path.clone()).unwrap();
+                Mnemonic::from_str(&contents).unwrap()
+            }
+            Err(_e) => {
+                let mut rng = rand::thread_rng();
+                let random_bytes: [u8; 32] = rng.gen();
+
+                let mnemnic = Mnemonic::from_entropy(&random_bytes).unwrap();
+                tracing::info!("Using randomly generated seed you will not be able to restore");
+
+                mnemnic
+            }
+        };
+
+        let mut wallets: HashMap<UncheckedUrl, Wallet> = HashMap::new();
+
+        let mints = localstore.get_mints().await.unwrap();
+
+        for (mint, _) in mints {
+            let wallet = Wallet::new(
+                &mint.to_string(),
+                cdk::nuts::CurrencyUnit::Sat,
+                localstore.clone(),
+                &mnemonic.to_seed_normalized(""),
+                None,
+            );
+
+            wallets.insert(mint, wallet);
+        }
+        wallets
     }
 
     #[tokio::test]
     async fn test_create_and_post_offer() {
+        let wallets = initialize_wallets().await;
+        let wallet = match wallets.get(&UncheckedUrl::new(MINT_URL.to_string())) {
+            Some(wallet) => wallet.clone(),
+            None => todo!(),
+        };
         const ANNOUNCEMENT: &str = "ypyyyX6pdZUM+OovHftxK9StImd8F7nxmr/eTeyR/5koOVVe/EaNw1MAeJm8LKDV1w74Fr+UJ+83bVP3ynNmjwKbtJr9eP5ie2Exmeod7kw4uNsuXcw6tqJF1FXH3fTF/dgiOwAByEOAEd95715DKrSLVdN/7cGtOlSRTQ0/LsW/p3BiVOdlpccA/dgGDAACBDEyMzQENDU2NwR0ZXN0";
         let announcement = oracle_announcement_from_str(ANNOUNCEMENT);
         let announcement_id =
@@ -405,6 +546,7 @@ mod tests {
         let amount = 7;
         let _event_id = dlc
             .create_bet(
+                &wallet,
                 announcement,
                 announcement_id,
                 counterparty_keys.public_key(),

--- a/crates/cdk-cli/src/sub_commands/send.rs
+++ b/crates/cdk-cli/src/sub_commands/send.rs
@@ -108,6 +108,7 @@ pub async fn send(
                 refund_keys,
                 sub_command_args.required_sigs,
                 None,
+                None,
             )
             .unwrap();
 
@@ -142,6 +143,7 @@ pub async fn send(
                     pubkeys,
                     refund_keys,
                     sub_command_args.required_sigs,
+                    None,
                     None,
                 )
                 .unwrap();

--- a/crates/cdk/src/nuts/nutdlc/mod.rs
+++ b/crates/cdk/src/nuts/nutdlc/mod.rs
@@ -90,6 +90,20 @@ impl ToString for DLCRoot {
     }
 }
 
+impl FromStr for DLCRoot {
+    type Err = crate::nuts::nut11::Error;
+
+    fn from_str(s: &str) -> Result<Self, crate::nuts::nut11::Error> {
+        let bytes = hex::decode(s).map_err(|_| crate::nuts::nut11::Error::InvalidHash)?;
+        if bytes.len() != 32 {
+            return Err(crate::nuts::nut11::Error::InvalidHash);
+        }
+        let mut array = [0u8; 32];
+        array.copy_from_slice(&bytes);
+        Ok(DLCRoot(array))
+    }
+}
+
 struct DLCMerkleTree {
     root: DLCRoot,
     leaves: Vec<DLCLeaf>,
@@ -109,11 +123,6 @@ pub struct DLCFundingToken {
     /// DLC Root
     pub dlc_root: DLCRoot,
 }
-
-// struct DLCSpendingConditions {
-//     data: DLCRoot,
-//     conditions: Option<SpendingConditions>,
-// }
 
 struct DLC {
     /// DLC Root

--- a/crates/cdk/src/nuts/nutsct/mod.rs
+++ b/crates/cdk/src/nuts/nutsct/mod.rs
@@ -1,6 +1,8 @@
 use bitcoin::hashes::sha256::Hash as Sha256Hash;
 use bitcoin::hashes::Hash;
 
+use crate::secret::Secret;
+
 pub fn sorted_merkle_hash(left: &[u8], right: &[u8]) -> [u8; 32] {
     // sort the inputs
     let (left, right) = if left < right {
@@ -40,4 +42,13 @@ pub fn merkle_verify(root: &[u8; 32], leaf_hash: &[u8; 32], proof: &[&[u8; 32]])
     }
 
     return h == root;
+}
+
+pub fn sct_root(secrets: Vec<Secret>) -> [u8; 32] {
+    let leaf_hashes: Vec<[u8; 32]> = secrets
+        .iter()
+        .map(|s| Sha256Hash::hash(&s.to_bytes()).to_byte_array())
+        .collect();
+
+    merkle_root(&leaf_hashes)
 }

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -1749,7 +1749,7 @@ impl Wallet {
                 todo!()
             }
 
-            SpendingConditions::SCTConditions { data, conditions } => {
+            SpendingConditions::SCTConditions { data } => {
                 todo!()
             }
         };

--- a/crates/cdk/src/wallet/mod.rs
+++ b/crates/cdk/src/wallet/mod.rs
@@ -1745,9 +1745,13 @@ impl Wallet {
                 ),
                 None => (None, None, None, None),
             },
-            SpendingConditions::DLCConditions { data, conditions } =>{ todo!()}
+            SpendingConditions::DLCConditions { data, conditions } => {
+                todo!()
+            }
 
-            SpendingConditions::SCTConditions { data, conditions } => {todo!()}
+            SpendingConditions::SCTConditions { data, conditions } => {
+                todo!()
+            }
         };
 
         if refund_keys.is_some() && locktime.is_none() {


### PR DESCRIPTION
built on #8 

allows proofs to be created with an SCT secret

creates a backup secret for the dlc funding token and creates and SCT out of the backup secret and the DLC secret

still need to backup the backup secret