### PR TITLE
feat: enforce keyset expiry

### DIFF
--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -1,0 +1,177 @@
+# Automated Code Review Instructions
+
+You are reviewing a pull request in the `cashubtc/cdk` repository. This repository contains the Cashu Development Kit (CDK), a Rust workspace implementing the Cashu e-cash protocol. 
+
+These instructions are distilled from the actual review patterns of the project's principal maintainers over recent PR comments.
+
+## Review Philosophy
+
+You are a careful, security-minded Rust reviewer. Your job is to catch real bugs, ensure strict adherence to the Cashu protocol specifications (NUTs), and maintain idiomatic, high-performance Rust code. Prioritize issues in this order:
+
+1. **Safety & Correctness** — Panics in production code, improper error handling, logical flaws.
+2. **Protocol Alignment (NUTs)** — Naming, JSON serialization, and behavior must match Cashu specs exactly.
+3. **Database Integrity** — Migrations must be immutable and handled correctly.
+4. **Performance & Bloat** — Dependency hygiene, avoiding unnecessary memory allocations or inefficient iterations.
+5. **Readability & Idiom** — Proper formatting, clean control flow, structured logging.
+
+**Approach**: When pushing back, phrase as a question first ("Why not...?", "Should we...?") and suggest a concrete alternative. Flat directives are reserved for true correctness, safety, or protocol-breaking problems.
+
+## 1. Error Handling & Safety
+
+The most common safety issues flagged in reviews involve panics.
+
+*   **No `unwrap()` outside tests:** Flag and request the removal of ANY `.unwrap()` calls in production code. Tests (`#[cfg(test)]`) are the only exception.
+*   **Limit `expect()`:** Encourage returning a `Result` and bubbling up the error using the `?` operator over panicking with `.expect()`. If `expect()` must be used, the message must clearly explain *why* the invariant holds.
+*   **Proper Error Types:** Ensure custom, structured errors (using `thiserror`) are used. Do not return empty strings (`""`), default values, or generic `anyhow` errors when a specific state has failed.
+
+## 2. Dependency Management
+
+*   **Explicit Features:** When adding new dependencies to `Cargo.toml`, verify that they are added with `default-features = false`. Explicitly specify only the required features.
+    *   *Reasoning:* Reduces binary size, speeds up compilation, and prevents dependency conflicts.
+    *   *Example:* `ciborium = { version = "0.2.2", default-features = false, features = ["std"] }`
+
+## 3. Protocol Alignment (Cashu NUTs)
+
+The CDK must implement the Cashu specs exactly. 
+
+*   **Spec Consistency:** Variable and field names serialized to JSON MUST align perfectly with the Cashu NUT specifications.
+*   **Ergonomic Renaming:** If a field name in the spec is ambiguous or confusing in Rust (e.g., the spec calls it `inputs` but it represents proofs), encourage renaming it internally in Rust (e.g., `proofs`) while preserving the spec output using `#[serde(rename = "input")]`.
+*   **Serialization boundaries:** Ensure `serde` `Serialize`/`Deserialize` traits are used strictly for data parsing, not for mutating data or adding business logic. Logic should live in standard constructors, `FromStr`, or `TryFrom`.
+
+## 4. FFI Sync
+
+When a PR adds, removes, or changes methods on the `cdk` Wallet API, verify that the `cdk-ffi` crate is updated in the same PR.
+
+Check:
+
+*   `crates/cdk-ffi/src/wallet.rs` exports the changed API with `#[uniffi::export]`.
+*   `crates/cdk-ffi/src/wallet_trait.rs` stays in sync.
+*   FFI-compatible types and conversions are updated under `crates/cdk-ffi/src/types/`.
+
+Missing FFI updates should be treated as a warning or critical issue depending on whether the changed API is public/released.
+
+## 5. Database Migrations
+
+*   **Immutability of Migrations:** NEVER allow edits to existing `sqlx` migration files (`crates/cdk-sqlite/**/migrations/*.sql`). This breaks existing databases in production.
+*   **Adding Migrations:** Instruct the author to create a *new* migration file using the `sqlx cli` (e.g., `sqlx migrate add <name>`) from within the appropriate directory (like `crates/cdk-sqlite/src/wallet`).
+*   **Redb Considerations:** Note that new *optional* fields added to `cdk-redb` do not require explicit migrations as they cleanly deserialize to `None`.
+
+## 6. Idiomatic Rust & Clean Code
+
+Prefer and suggest:
+
+*   **Formatting:** Remind the user to run `cargo fmt` if there are missing newlines, trailing whitespaces, or styling issues.
+*   **Iterators:** Suggest using standard iterators like `.fold(Amount::ZERO, |acc, val| acc + val)` instead of chaining `.map().sum()` for better idiomatic structures and performance.
+*   **Control Flow:** Suggest `.then()` to avoid simple `if/else` assignments. Prefer pattern matching and `strip_prefix()` for string parsing over manual string slicing or indexing.
+*   **Logging:** Flag `println!` statements and request they be replaced with proper `tracing` macros (`info!`, `debug!`, etc.).
+*   **Dead Code:** Remove unused code instead of commenting it out.
+
+## 7. Build Scripts, CI & Tooling
+
+When reviewing shell scripts, CI workflows (GitHub Actions), or bindings generation:
+
+*   **Rely on Nix for Determinism:** The project uses Nix to guarantee a predictable environment. Do not introduce alternative tools (like `perl` over standard UNIX utilities) just to work around cross-platform portability quirks. Rely on the determinism of the Nix environment instead.
+*   **CI Workflows (Publishing):** Operations that mutate the repository (like tagging, bumping versions, or pushing commits) should ONLY occur *after* the actual publishing step (e.g., to Maven Central, crates.io) has succeeded. This ensures failures are easily retried without manual repository cleanup.
+
+## 8. Nix and CI Environment
+
+CDK uses Nix to provide deterministic development and CI environments.
+
+When reviewing CI, shell scripts, or binding-generation workflows:
+
+*   Prefer using the existing Nix environment over ad-hoc setup steps in GitHub Actions.
+*   Do not introduce extra tools solely for portability when the Nix environment already defines the toolchain.
+*   Before adding tools such as `cross`, platform-specific setup actions, or language toolchain installers, check whether the existing Nix environment already provides the needed target/toolchain.
+*   Avoid adding untested platform support. If nobody is testing or willing to maintain Windows support, prefer removing it over carrying a broken or unverified workflow.
+
+## 9. Branch Hygiene
+
+Feature branches should be kept up to date by rebasing onto upstream `main`, not by merging `main` into the feature branch.
+
+This matches `DEVELOPMENT.md` and keeps PR history linear and easier to review:
+
+```bash
+git fetch upstream
+git rebase upstream/main
+```
+
+Flag PRs that include merge commits from `main` or noisy history caused by merging `main` into the feature branch. Ask the author to rebase instead.
+
+## What NOT to flag
+
+*   Do not flag `unwrap()` in test code (`#[cfg(test)]`) — it's acceptable there.
+*   Do not suggest changes to files you haven't been shown in the diff.
+*   Do not suggest reformatting code that follows the project's existing style (let `rustfmt` handle this).
+
+## Output Format
+
+Default to a human-readable GitHub review format unless the caller explicitly requests JSON or an automated review bot requires structured output.
+
+Use this structure:
+
+### Findings
+
+List findings first, ordered by severity. Each finding should include:
+
+*   severity: `critical`, `warning`, or `nit`
+*   file and line reference
+*   concise explanation of the issue
+*   concrete suggested fix when useful
+
+Example:
+
+```text
+warning: crates/cdk/src/wallet/mod.rs:42
+
+Should this return a structured error instead of panicking? This path can be reached from wallet API callers, so `?` with a domain error would avoid crashing the process.
+```
+
+### Summary
+
+Keep the summary short. Mention only what was reviewed and any important residual risk.
+
+### Verdict
+
+Use one of:
+
+*   `APPROVE` — no critical or warning-level issues found.
+*   `COMMENT` — findings are present, or the reviewer is unsure.
+*   `CHANGES_REQUESTED` — critical correctness, safety, protocol, migration, or release-blocking issues are present.
+
+Do not duplicate findings in the summary if they are already listed above.
+
+## Automated JSON Output
+
+If the review is being consumed by automation and JSON is explicitly requested, output valid JSON and nothing else.
+
+Schema:
+
+```json
+{
+  "verdict": "APPROVE | COMMENT | CHANGES_REQUESTED",
+  "reason": "null, or a short explanation of why the PR was not auto-approved (only when verdict is COMMENT and the reason is non-obvious).",
+  "inline_comments": [
+    {
+      "path": "relative/path/to/file.rs",
+      "line": 42,
+      "side": "RIGHT",
+      "severity": "critical | warning | nit",
+      "body": "Explanation of the issue."
+    }
+  ]
+}
+```
+
+Field details:
+
+*   **verdict**: `APPROVE` — no critical or warning-level issues, change is safe. `COMMENT` — use for all other cases: PRs with issues found, or when unsure. `CHANGES_REQUESTED` — critical correctness, safety, protocol, or migration problems.
+*   **reason**: `null` when approving, or when the inline comments already make the reason obvious. Only set this to a short sentence when the verdict is COMMENT and a human needs to understand what to focus on beyond the inline comments.
+*   **inline_comments**: Array of line-level comments. All findings — bugs, nits, warnings — MUST go here as inline comments, not in a top-level summary. Can be empty if the change is clean.
+    *   **path**: File path relative to repo root, as shown in the diff.
+    *   **line**: The line number in the diff to attach the comment to.
+    *   **side**: `RIGHT` for lines in the new version (additions, context on new side), `LEFT` for lines in the old version (deletions). When in doubt, use `RIGHT`.
+    *   **severity**:
+        *   `critical` — panics (`unwrap`), protocol-breaking naming/serialization changes, edited past SQL migrations.
+        *   `warning` — missing default-features flags, `expect` usage, logic flaws, merge commits from main.
+        *   `nit` — `.map().sum()`, `println!`, missing `cargo fmt`.
+    *   **body**: The comment text. Be specific and actionable. Where helpful, suggest the concrete code alternative.

--- a/.github/agents/review.md
+++ b/.github/agents/review.md
@@ -11,8 +11,10 @@ You are a careful, security-minded Rust reviewer. Your job is to catch real bugs
 1. **Safety & Correctness** — Panics in production code, improper error handling, logical flaws.
 2. **Protocol Alignment (NUTs)** — Naming, JSON serialization, and behavior must match Cashu specs exactly.
 3. **Database Integrity** — Migrations must be immutable and handled correctly.
-4. **Performance & Bloat** — Dependency hygiene, avoiding unnecessary memory allocations or inefficient iterations.
-5. **Readability & Idiom** — Proper formatting, clean control flow, structured logging.
+4. **Operational Correctness** — Startup behavior, reconnects, retries, timeouts, config validation, and degraded dependencies.
+5. **Compatibility & Public API Stability** — Public APIs, config formats, env vars, and FFI must stay compatible unless a breaking change is intentional.
+6. **Performance & Bloat** — Dependency hygiene, avoiding unnecessary memory allocations or inefficient work.
+7. **Readability & Idiom** — Proper formatting, clean control flow, structured logging.
 
 **Approach**: When pushing back, phrase as a question first ("Why not...?", "Should we...?") and suggest a concrete alternative. Flat directives are reserved for true correctness, safety, or protocol-breaking problems.
 
@@ -21,7 +23,7 @@ You are a careful, security-minded Rust reviewer. Your job is to catch real bugs
 The most common safety issues flagged in reviews involve panics.
 
 *   **No `unwrap()` outside tests:** Flag and request the removal of ANY `.unwrap()` calls in production code. Tests (`#[cfg(test)]`) are the only exception.
-*   **Limit `expect()`:** Encourage returning a `Result` and bubbling up the error using the `?` operator over panicking with `.expect()`. If `expect()` must be used, the message must clearly explain *why* the invariant holds.
+*   **Limit `expect()`:** Encourage returning a `Result` and bubbling up the error using the `?` operator over panicking with `.expect()`. `expect()` is acceptable only for impossible invariants with a message that clearly explains *why* the invariant holds. Treat `expect()` on config, env vars, network, database, parsing, user input, or request-dependent state as a warning or critical issue depending on impact.
 *   **Proper Error Types:** Ensure custom, structured errors (using `thiserror`) are used. Do not return empty strings (`""`), default values, or generic `anyhow` errors when a specific state has failed.
 
 ## 2. Dependency Management
@@ -29,6 +31,8 @@ The most common safety issues flagged in reviews involve panics.
 *   **Explicit Features:** When adding new dependencies to `Cargo.toml`, verify that they are added with `default-features = false`. Explicitly specify only the required features.
     *   *Reasoning:* Reduces binary size, speeds up compilation, and prevents dependency conflicts.
     *   *Example:* `ciborium = { version = "0.2.2", default-features = false, features = ["std"] }`
+*   **Avoid Redundant Features:** Check the dependency's feature graph and avoid listing features that are already enabled transitively by another selected feature.
+*   **Review Transitive Impact:** For existing dependencies gaining new features, verify that the new feature set does not pull in unnecessary runtime support, TLS stacks, executors, or platform-specific dependencies.
 
 ## 3. Protocol Alignment (Cashu NUTs)
 
@@ -50,30 +54,49 @@ Check:
 
 Missing FFI updates should be treated as a warning or critical issue depending on whether the changed API is public/released.
 
-## 5. Database Migrations
+## 5. Public API & Config Compatibility
+
+When reviewing public crates, binaries, or config structs, check whether the diff changes behavior for downstream users or deployed mints.
+
+*   **Public API Breakage:** Flag changes to public functions, constructors, traits, re-exported types, serialized types, or feature flags unless the PR clearly intends a breaking change.
+*   **Config Compatibility:** For config structs and env vars, verify that existing valid config files still deserialize and behave the same unless migration guidance is included.
+*   **Config Validation:** Invalid user config should fail with a clear startup/config error, not panic later through `unwrap()` or `expect()`.
+*   **Defaults and Precedence:** Check that defaults, env overrides, and file config precedence remain consistent and are tested when changed.
+
+## 6. Database Migrations
 
 *   **Immutability of Migrations:** NEVER allow edits to existing `sqlx` migration files (`crates/cdk-sqlite/**/migrations/*.sql`). This breaks existing databases in production.
 *   **Adding Migrations:** Instruct the author to create a *new* migration file using the `sqlx cli` (e.g., `sqlx migrate add <name>`) from within the appropriate directory (like `crates/cdk-sqlite/src/wallet`).
 *   **Redb Considerations:** Note that new *optional* fields added to `cdk-redb` do not require explicit migrations as they cleanly deserialize to `None`.
 
-## 6. Idiomatic Rust & Clean Code
+## 7. Operational Correctness
+
+Review runtime behavior for long-lived services and external dependencies.
+
+*   **Startup Failure Modes:** Configuration, dependency initialization, and migrations should fail clearly at startup instead of panicking or failing later during request handling.
+*   **Reconnects and Retries:** For networked backends, caches, databases, RPC clients, and Lightning backends, verify that connection reuse preserves recovery after restarts, dropped connections, topology changes, and transient errors.
+*   **Timeouts and Backoff:** Long-running or remote operations should have explicit timeout/backoff behavior when the surrounding code expects bounded latency.
+*   **Degraded Dependencies:** Optional infrastructure such as caches and metrics should degrade according to the existing contract and should not accidentally become required.
+*   **Resource Reuse:** Connection pooling or reuse should use the dependency's intended long-lived abstraction when available, not a raw connection handle that cannot recover.
+
+## 8. Idiomatic Rust & Clean Code
 
 Prefer and suggest:
 
 *   **Formatting:** Remind the user to run `cargo fmt` if there are missing newlines, trailing whitespaces, or styling issues.
-*   **Iterators:** Suggest using standard iterators like `.fold(Amount::ZERO, |acc, val| acc + val)` instead of chaining `.map().sum()` for better idiomatic structures and performance.
-*   **Control Flow:** Suggest `.then()` to avoid simple `if/else` assignments. Prefer pattern matching and `strip_prefix()` for string parsing over manual string slicing or indexing.
+*   **Iterators:** Consider suggesting standard iterators like `.fold(Amount::ZERO, |acc, val| acc + val)` instead of chaining `.map().sum()` only when it improves clarity, avoids allocations, or matches nearby code.
+*   **Control Flow:** Prefer pattern matching and `strip_prefix()` for string parsing over manual string slicing or indexing. Suggest `.then()` only when it makes a simple conditional assignment clearer.
 *   **Logging:** Flag `println!` statements and request they be replaced with proper `tracing` macros (`info!`, `debug!`, etc.).
 *   **Dead Code:** Remove unused code instead of commenting it out.
 
-## 7. Build Scripts, CI & Tooling
+## 9. Build Scripts, CI & Tooling
 
 When reviewing shell scripts, CI workflows (GitHub Actions), or bindings generation:
 
 *   **Rely on Nix for Determinism:** The project uses Nix to guarantee a predictable environment. Do not introduce alternative tools (like `perl` over standard UNIX utilities) just to work around cross-platform portability quirks. Rely on the determinism of the Nix environment instead.
 *   **CI Workflows (Publishing):** Operations that mutate the repository (like tagging, bumping versions, or pushing commits) should ONLY occur *after* the actual publishing step (e.g., to Maven Central, crates.io) has succeeded. This ensures failures are easily retried without manual repository cleanup.
 
-## 8. Nix and CI Environment
+## 10. Nix and CI Environment
 
 CDK uses Nix to provide deterministic development and CI environments.
 
@@ -84,7 +107,7 @@ When reviewing CI, shell scripts, or binding-generation workflows:
 *   Before adding tools such as `cross`, platform-specific setup actions, or language toolchain installers, check whether the existing Nix environment already provides the needed target/toolchain.
 *   Avoid adding untested platform support. If nobody is testing or willing to maintain Windows support, prefer removing it over carrying a broken or unverified workflow.
 
-## 9. Branch Hygiene
+## 11. Branch Hygiene
 
 Feature branches should be kept up to date by rebasing onto upstream `main`, not by merging `main` into the feature branch.
 
@@ -100,6 +123,7 @@ Flag PRs that include merge commits from `main` or noisy history caused by mergi
 ## What NOT to flag
 
 *   Do not flag `unwrap()` in test code (`#[cfg(test)]`) — it's acceptable there.
+*   Do not over-review test style. Comment on test names, structure, or helper shape only when it hides behavior, duplicates too much logic, or misses an important scenario.
 *   Do not suggest changes to files you haven't been shown in the diff.
 *   Do not suggest reformatting code that follows the project's existing style (let `rustfmt` handle this).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,8 @@ Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`.
 
 ## Docs & References
 
+**If you are reviewing PRs or code changes, always refer to the specific review guidelines in `.github/agents/review.md` for project-specific feedback standards.**
+
 | Document | Path |
 |---|---|
 | Developer setup & workflow | `DEVELOPMENT.md` |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ ldk-node = "0.7.0"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 thiserror = { version = "2" }
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "test-util", "sync"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "test-util", "sync", "time"] }
 tokio-util = { version = "0.7.11", default-features = false }
 tower = "0.5.2"
 tower-http = { version = "0.6.1", features = ["compression-full", "decompression-full", "cors", "trace", "fs"] }

--- a/bindings/dart/test/wallet_test.dart
+++ b/bindings/dart/test/wallet_test.dart
@@ -30,6 +30,28 @@ void main() {
     expect(balance.value, equals(0));
   });
 
+  test('in-memory sqlite handles concurrent access', () async {
+    final memoryWallet = Wallet(
+      mintUrl: 'https://testnut.cashudevkit.org',
+      unit: SatCurrencyUnit(),
+      mnemonic: generateMnemonic(),
+      store: SqliteWalletStore(':memory:'),
+      config: WalletConfig(targetProofCount: null),
+    );
+
+    try {
+      final balances = await Future.wait(
+        List.generate(64, (_) => memoryWallet.totalBalance()),
+      );
+
+      for (final balance in balances) {
+        expect(balance.value, equals(0));
+      }
+    } finally {
+      memoryWallet.dispose();
+    }
+  });
+
   test('mint flow', () async {
     final quote = await wallet.mintQuote(
       paymentMethod: Bolt11PaymentMethod(),

--- a/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
+++ b/bindings/kotlin/cdk-jvm/src/test/kotlin/org/cashudevkit/WalletTest.kt
@@ -1,5 +1,8 @@
 package org.cashudevkit
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -35,6 +38,31 @@ class WalletTest {
     fun `initial balance is zero`() = runBlocking {
         val balance = wallet.totalBalance()
         assertEquals(0UL, balance.value)
+    }
+
+    @Test
+    fun `in-memory sqlite handles concurrent access`() = runBlocking {
+        val memoryWallet = Wallet(
+            mintUrl = "https://testnut.cashudevkit.org",
+            unit = CurrencyUnit.Sat,
+            mnemonic = generateMnemonic(),
+            store = WalletStore.Sqlite(path = ":memory:"),
+            config = WalletConfig(targetProofCount = null),
+        )
+
+        try {
+            val balances = coroutineScope {
+                (0 until 64).map {
+                    async { memoryWallet.totalBalance() }
+                }.awaitAll()
+            }
+
+            balances.forEach { balance ->
+                assertEquals(0UL, balance.value)
+            }
+        } finally {
+            memoryWallet.close()
+        }
     }
 
     @Test

--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -1,12 +1,13 @@
-import XCTest
+import Testing
+import Foundation
 @testable import Cdk
 
-final class CdkTests: XCTestCase {
-    private var wallet: Wallet!
-    private var dbPath: String!
+@Suite("Cdk Wallet Tests")
+struct CdkTests {
+    private let wallet: Wallet
+    private let dbPath: String
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() async throws {
         let tempDir = FileManager.default.temporaryDirectory
         dbPath = tempDir.appendingPathComponent(UUID().uuidString + ".sqlite").path
         wallet = try Wallet(
@@ -18,20 +19,14 @@ final class CdkTests: XCTestCase {
         )
     }
 
-    override func tearDown() async throws {
-        wallet = nil
-        if let path = dbPath {
-            try? FileManager.default.removeItem(atPath: path)
-        }
-        try await super.tearDown()
-    }
-
-    func testInitialBalanceIsZero() async throws {
+    @Test("Initial balance is zero")
+    func initialBalanceIsZero() async throws {
         let balance = try await wallet.totalBalance()
-        XCTAssertEqual(balance.value, 0, "New wallet should have zero balance")
+        #expect(balance.value == 0, "New wallet should have zero balance")
     }
 
-    func testMintFlow() async throws {
+    @Test("Mint flow completes successfully")
+    func mintFlow() async throws {
         let quote = try await wallet.mintQuote(
             paymentMethod: .bolt11,
             amount: Amount(value: 100),
@@ -39,8 +34,8 @@ final class CdkTests: XCTestCase {
             extra: nil
         )
 
-        XCTAssertFalse(quote.id.isEmpty, "Quote should have a non-empty id")
-        XCTAssertFalse(quote.request.isEmpty, "Quote should have a non-empty payment request")
+        #expect(!quote.id.isEmpty, "Quote should have a non-empty id")
+        #expect(!quote.request.isEmpty, "Quote should have a non-empty payment request")
 
         // testnut pays quotes automatically, wait briefly for payment to settle
         try await Task.sleep(nanoseconds: 3_000_000_000)
@@ -51,9 +46,9 @@ final class CdkTests: XCTestCase {
             spendingConditions: nil
         )
 
-        XCTAssertFalse(proofs.isEmpty, "Should have received proofs")
+        #expect(!proofs.isEmpty, "Should have received proofs")
 
         let balance = try await wallet.totalBalance()
-        XCTAssertEqual(balance.value, 100, "Balance should be 100 after minting")
+        #expect(balance.value == 100, "Balance should be 100 after minting")
     }
 }

--- a/bindings/swift/Tests/CdkTests.swift
+++ b/bindings/swift/Tests/CdkTests.swift
@@ -25,6 +25,36 @@ struct CdkTests {
         #expect(balance.value == 0, "New wallet should have zero balance")
     }
 
+    @Test("In-memory SQLite handles concurrent access")
+    func inMemorySqliteHandlesConcurrentAccess() async throws {
+        let memoryWallet = try Wallet(
+            mintUrl: "https://testnut.cashudevkit.org",
+            unit: .sat,
+            mnemonic: try generateMnemonic(),
+            store: .sqlite(path: ":memory:"),
+            config: WalletConfig(targetProofCount: nil)
+        )
+
+        let balances = try await withThrowingTaskGroup(of: Amount.self) { group in
+            for _ in 0..<64 {
+                group.addTask {
+                    try await memoryWallet.totalBalance()
+                }
+            }
+
+            var balances: [Amount] = []
+            for try await balance in group {
+                balances.append(balance)
+            }
+            return balances
+        }
+
+        #expect(balances.count == 64, "All concurrent balance reads should complete")
+        for balance in balances {
+            #expect(balance.value == 0, "New in-memory wallet should have zero balance")
+        }
+    }
+
     @Test("Mint flow completes successfully")
     func mintFlow() async throws {
         let quote = try await wallet.mintQuote(

--- a/crates/cashu/src/nuts/auth/nut21.rs
+++ b/crates/cashu/src/nuts/auth/nut21.rs
@@ -104,6 +104,15 @@ impl ProtectedEndpoint {
     pub fn new(method: Method, path: RoutePath) -> Self {
         Self { method, path }
     }
+
+    /// Returns how specifically this protected endpoint matches a request endpoint.
+    pub fn match_specificity(&self, endpoint: &Self) -> Option<usize> {
+        if self.method != endpoint.method {
+            return None;
+        }
+
+        self.path.match_specificity(&endpoint.path)
+    }
 }
 
 /// HTTP method
@@ -121,6 +130,8 @@ pub enum Method {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "swagger", derive(utoipa::ToSchema))]
 pub enum RoutePath {
+    /// Wildcard route path prefix
+    Wildcard(String),
     /// Mint Quote for a specific payment method
     MintQuote(String),
     /// Mint for a specific payment method
@@ -154,6 +165,10 @@ impl std::str::FromStr for RoutePath {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(prefix) = s.strip_suffix('*') {
+            return Self::wildcard(prefix.to_string());
+        }
+
         // Try to parse as a known static path first
         match s {
             "/v1/swap" => Ok(RoutePath::Swap),
@@ -192,6 +207,36 @@ impl<'de> Deserialize<'de> for RoutePath {
 }
 
 impl RoutePath {
+    /// Create a wildcard route path.
+    pub fn wildcard(prefix: String) -> Result<Self, Error> {
+        if prefix.contains('*') {
+            return Err(Error::InvalidPattern(
+                "Wildcard '*' must be the last character".to_string(),
+            ));
+        }
+
+        Ok(Self::Wildcard(prefix))
+    }
+
+    /// Returns true if this route path is a wildcard pattern.
+    pub fn is_wildcard(&self) -> bool {
+        matches!(self, Self::Wildcard(_))
+    }
+
+    /// Returns how specifically this route matches an endpoint.
+    ///
+    /// Exact routes are always preferred over wildcard routes. Wildcard routes
+    /// are ranked by prefix length so `/v1/mint/quote/*` wins over `/v1/*`.
+    pub fn match_specificity(&self, endpoint: &Self) -> Option<usize> {
+        match self {
+            Self::Wildcard(prefix) if endpoint.to_string().starts_with(prefix) => {
+                Some(prefix.len())
+            }
+            _ if self == endpoint => Some(usize::MAX),
+            _ => None,
+        }
+    }
+
     /// Get all non-payment-method route paths
     /// These are routes that don't depend on payment methods
     pub fn static_paths() -> Vec<RoutePath> {
@@ -232,19 +277,17 @@ impl RoutePath {
 pub fn matching_route_paths(pattern: &str) -> Result<Vec<RoutePath>, Error> {
     // Check for wildcard
     if let Some(prefix) = pattern.strip_suffix('*') {
-        // Prefix matching
-        // Ensure '*' is only at the end
-        if prefix.contains('*') {
-            return Err(Error::InvalidPattern(
-                "Wildcard '*' must be the last character".to_string(),
-            ));
-        }
+        let wildcard = RoutePath::wildcard(prefix.to_string())?;
 
         // Filter all known paths
-        Ok(RoutePath::all_known_paths()
+        let mut paths: Vec<RoutePath> = RoutePath::all_known_paths()
             .into_iter()
             .filter(|path| path.to_string().starts_with(prefix))
-            .collect())
+            .collect();
+
+        paths.push(wildcard);
+
+        Ok(paths)
     } else {
         // Exact matching
         if pattern.contains('*') {
@@ -255,13 +298,14 @@ pub fn matching_route_paths(pattern: &str) -> Result<Vec<RoutePath>, Error> {
 
         match RoutePath::from_str(pattern) {
             Ok(path) => Ok(vec![path]),
-            Err(_) => Ok(vec![]), // Ignore unknown paths for matching
+            Err(e) => Err(e),
         }
     }
 }
 impl std::fmt::Display for RoutePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            RoutePath::Wildcard(prefix) => write!(f, "{}*", prefix),
             RoutePath::MintQuote(method) => write!(f, "/v1/mint/quote/{}", method),
             RoutePath::Mint(method) => write!(f, "/v1/mint/{}", method),
             RoutePath::MeltQuote(method) => write!(f, "/v1/melt/quote/{}", method),
@@ -287,8 +331,9 @@ mod tests {
         // Pattern that matches everything
         let paths = matching_route_paths("*").unwrap();
 
-        // Should match all known variants
-        assert_eq!(paths.len(), RoutePath::all_known_paths().len());
+        // Should match all known variants plus the wildcard policy.
+        assert_eq!(paths.len(), RoutePath::all_known_paths().len() + 1);
+        assert!(paths.contains(&RoutePath::Wildcard(String::new())));
     }
 
     #[test]
@@ -304,8 +349,9 @@ mod tests {
         // "/v1/mint*" matches "/v1/mint" and "/v1/mint/..."
         let paths = matching_route_paths("/v1/mint*").unwrap();
 
-        // Should match all mint paths + mint quote paths
-        assert_eq!(paths.len(), 4);
+        // Should match all mint paths + mint quote paths plus the wildcard policy.
+        assert_eq!(paths.len(), 5);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/mint".to_string())));
 
         // Should NOT match /v1/melt...
         assert!(!paths.contains(&RoutePath::MeltQuote(
@@ -315,9 +361,11 @@ mod tests {
 
     #[test]
     fn test_matching_route_paths_exact_match_unknown() {
-        // Exact match for unknown path structure should return empty list
-        let paths = matching_route_paths("/v1/invalid/path").unwrap();
-        assert!(paths.is_empty());
+        let result = matching_route_paths("/v1/invalid/path");
+        assert!(matches!(
+            result,
+            Err(Error::UnknownRoute(route)) if route == "/v1/invalid/path"
+        ));
     }
 
     #[test]
@@ -333,8 +381,9 @@ mod tests {
         // Prefix that matches all paths
         let paths = matching_route_paths("/v1/*").unwrap();
 
-        // Should match all known variants
-        assert_eq!(paths.len(), RoutePath::all_known_paths().len());
+        // Should match all known variants plus the wildcard policy.
+        assert_eq!(paths.len(), RoutePath::all_known_paths().len() + 1);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/".to_string())));
 
         // Verify all variants are included
         assert!(paths.contains(&RoutePath::MintQuote(
@@ -366,8 +415,9 @@ mod tests {
         // Regex that matches only mint paths
         let paths = matching_route_paths("/v1/mint/*").unwrap();
 
-        // Should match only mint paths (4 paths: mint quote and mint for bolt11 and bolt12)
-        assert_eq!(paths.len(), 4);
+        // Should match mint paths plus the wildcard policy.
+        assert_eq!(paths.len(), 5);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/mint/".to_string())));
         assert!(paths.contains(&RoutePath::MintQuote(
             PaymentMethod::Known(KnownMethod::Bolt11).to_string()
         )));
@@ -402,8 +452,9 @@ mod tests {
         // Regex that matches only quote paths
         let paths = matching_route_paths("/v1/mint/quote/*").unwrap();
 
-        // Should match only quote paths (2 paths: mint quote for bolt11 and bolt12)
-        assert_eq!(paths.len(), 2);
+        // Should match quote paths plus the wildcard policy.
+        assert_eq!(paths.len(), 3);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/mint/quote/".to_string())));
         assert!(paths.contains(&RoutePath::MintQuote(
             PaymentMethod::Known(KnownMethod::Bolt11).to_string()
         )));
@@ -422,11 +473,11 @@ mod tests {
 
     #[test]
     fn test_matching_route_paths_no_match() {
-        // Regex that matches nothing
-        let paths = matching_route_paths("/nonexistent/path").unwrap();
-
-        // Should match nothing
-        assert!(paths.is_empty());
+        let result = matching_route_paths("/nonexistent/path");
+        assert!(matches!(
+            result,
+            Err(Error::UnknownRoute(route)) if route == "/nonexistent/path"
+        ));
     }
 
     #[test]
@@ -455,6 +506,10 @@ mod tests {
     fn test_route_path_to_string() {
         // Test that to_string() returns the correct path strings
         assert_eq!(
+            RoutePath::Wildcard("/v1/mint/".to_string()).to_string(),
+            "/v1/mint/*"
+        );
+        assert_eq!(
             RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()).to_string(),
             "/v1/mint/quote/bolt11"
         );
@@ -478,6 +533,40 @@ mod tests {
         assert_eq!(RoutePath::Checkstate.to_string(), "/v1/checkstate");
         assert_eq!(RoutePath::Restore.to_string(), "/v1/restore");
         assert_eq!(RoutePath::MintBlindAuth.to_string(), "/v1/auth/blind/mint");
+    }
+
+    #[test]
+    fn test_route_path_is_wildcard() {
+        assert!(RoutePath::Wildcard("/v1/mint/".to_string()).is_wildcard());
+        assert!(!RoutePath::MintQuote("bolt11".to_string()).is_wildcard());
+        assert!(!RoutePath::Swap.is_wildcard());
+    }
+
+    #[test]
+    fn test_protected_endpoint_match_specificity() {
+        let request = ProtectedEndpoint::new(
+            Method::Post,
+            RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+        );
+        let exact = ProtectedEndpoint::new(
+            Method::Post,
+            RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+        );
+        let wildcard =
+            ProtectedEndpoint::new(Method::Post, RoutePath::Wildcard("/v1/mint/".to_string()));
+        let different_method = ProtectedEndpoint::new(
+            Method::Get,
+            RoutePath::MintQuote(PaymentMethod::Known(KnownMethod::Bolt11).to_string()),
+        );
+        let non_matching_path = ProtectedEndpoint::new(Method::Post, RoutePath::Swap);
+
+        assert_eq!(exact.match_specificity(&request), Some(usize::MAX));
+        assert_eq!(
+            wildcard.match_specificity(&request),
+            Some("/v1/mint/".len())
+        );
+        assert_eq!(different_method.match_specificity(&request), None);
+        assert_eq!(non_matching_path.match_specificity(&request), None);
     }
 
     #[test]
@@ -572,7 +661,7 @@ mod tests {
             "https://example.com/.well-known/openid-configuration"
         );
         assert_eq!(settings.client_id, "client123");
-        assert_eq!(settings.protected_endpoints.len(), 5); // 4 mint paths (bolt11+bolt12 quote+mint) + 1 swap path
+        assert_eq!(settings.protected_endpoints.len(), 6); // 4 mint paths + wildcard + 1 swap path
 
         let expected_protected: HashSet<ProtectedEndpoint> = HashSet::from_iter(vec![
             ProtectedEndpoint::new(Method::Post, RoutePath::Swap),
@@ -592,6 +681,7 @@ mod tests {
                 Method::Get,
                 RoutePath::Mint(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
             ),
+            ProtectedEndpoint::new(Method::Get, RoutePath::Wildcard("/v1/mint/".to_string())),
         ]);
 
         let deserlized_protected = settings.protected_endpoints.into_iter().collect();
@@ -608,6 +698,23 @@ mod tests {
                 {
                     "method": "GET",
                     "path": "/*wildcard_start"
+                }
+            ]
+        }"#;
+
+        let result = serde_json::from_str::<Settings>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_settings_deserialize_unknown_exact_path() {
+        let json = r#"{
+            "openid_discovery": "https://example.com/.well-known/openid-configuration",
+            "client_id": "client123",
+            "protected_endpoints": [
+                {
+                    "method": "POST",
+                    "path": "/v1/swp"
                 }
             ]
         }"#;
@@ -654,22 +761,20 @@ mod tests {
         let settings: Settings = serde_json::from_str(json).unwrap();
         assert_eq!(
             settings.protected_endpoints.len(),
-            RoutePath::all_known_paths().len()
+            RoutePath::all_known_paths().len() + 1
         );
     }
 
     #[test]
     fn test_matching_route_paths_empty_pattern() {
-        // Empty pattern should return empty list (nothing matches)
-        let paths = matching_route_paths("").unwrap();
-        assert!(paths.is_empty());
+        let result = matching_route_paths("");
+        assert!(matches!(result, Err(Error::UnknownRoute(route)) if route.is_empty()));
     }
 
     #[test]
     fn test_matching_route_paths_just_slash() {
-        // Pattern "/" should not match any known paths (all start with /v1/)
-        let paths = matching_route_paths("/").unwrap();
-        assert!(paths.is_empty());
+        let result = matching_route_paths("/");
+        assert!(matches!(result, Err(Error::UnknownRoute(route)) if route == "/"));
     }
 
     #[test]
@@ -743,8 +848,9 @@ mod tests {
         // Test prefix matching for melt endpoints: "/v1/melt/*"
         let paths = matching_route_paths("/v1/melt/*").unwrap();
 
-        // Should match 4 melt paths (bolt11/12 for melt and melt quote)
-        assert_eq!(paths.len(), 4);
+        // Should match 4 melt paths plus the wildcard policy.
+        assert_eq!(paths.len(), 5);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/melt/".to_string())));
         assert!(paths.contains(&RoutePath::Melt(
             PaymentMethod::Known(KnownMethod::Bolt11).to_string()
         )));
@@ -834,7 +940,8 @@ mod tests {
     fn test_matching_route_paths_only_wildcard() {
         // Pattern with just "*" matches everything
         let paths = matching_route_paths("*").unwrap();
-        assert_eq!(paths.len(), RoutePath::all_known_paths().len());
+        assert_eq!(paths.len(), RoutePath::all_known_paths().len() + 1);
+        assert!(paths.contains(&RoutePath::Wildcard(String::new())));
     }
 
     #[test]
@@ -849,20 +956,12 @@ mod tests {
 
     #[test]
     fn test_exact_match_no_child_paths() {
-        // Exact match "/v1/mint" should NOT match child paths like "/v1/mint/bolt11"
-        let paths = matching_route_paths("/v1/mint").unwrap();
-
-        // "/v1/mint" is not a valid RoutePath by itself (needs payment method)
-        // So it should return empty
-        assert!(paths.is_empty());
-
-        // Also verify it doesn't match any mint paths with payment methods
-        assert!(!paths.contains(&RoutePath::Mint(
-            PaymentMethod::Known(KnownMethod::Bolt11).to_string()
-        )));
-        assert!(!paths.contains(&RoutePath::MintQuote(
-            PaymentMethod::Known(KnownMethod::Bolt11).to_string()
-        )));
+        // Exact match "/v1/mint" is not a valid RoutePath by itself.
+        let result = matching_route_paths("/v1/mint");
+        assert!(matches!(
+            result,
+            Err(Error::UnknownRoute(route)) if route == "/v1/mint"
+        ));
     }
 
     #[test]
@@ -954,11 +1053,14 @@ mod tests {
         let paths_upper = matching_route_paths("/v1/MINT/*").unwrap();
         let paths_lower = matching_route_paths("/v1/mint/*").unwrap();
 
-        // Uppercase should NOT match any known paths
-        assert!(paths_upper.is_empty());
+        // Uppercase should not match any known paths, but the wildcard policy is preserved.
+        assert_eq!(
+            paths_upper,
+            vec![RoutePath::Wildcard("/v1/MINT/".to_string())]
+        );
 
-        // Lowercase should match 4 mint paths
-        assert_eq!(paths_lower.len(), 4);
+        // Lowercase should match 4 mint paths plus the wildcard policy.
+        assert_eq!(paths_lower.len(), 5);
     }
 
     #[test]
@@ -986,13 +1088,25 @@ mod tests {
         assert!(!swap_paths.contains(&RoutePath::Restore));
         assert!(!swap_paths.contains(&RoutePath::MintBlindAuth));
 
-        // 4. Case sensitivity - wrong case matches nothing
-        assert!(matching_route_paths("/V1/SWAP").unwrap().is_empty());
-        assert!(matching_route_paths("/V1/MINT/*").unwrap().is_empty());
+        // 4. Case sensitivity - wrong exact case fails, wildcard case is preserved.
+        assert!(matches!(
+            matching_route_paths("/V1/SWAP"),
+            Err(Error::UnknownRoute(route)) if route == "/V1/SWAP"
+        ));
+        assert_eq!(
+            matching_route_paths("/V1/MINT/*").unwrap(),
+            vec![RoutePath::Wildcard("/V1/MINT/".to_string())]
+        );
 
-        // 5. Invalid/unknown paths match nothing
-        assert!(matching_route_paths("/unknown/path").unwrap().is_empty());
-        assert!(matching_route_paths("/invalid").unwrap().is_empty());
+        // 5. Invalid/unknown exact paths fail closed.
+        assert!(matches!(
+            matching_route_paths("/unknown/path"),
+            Err(Error::UnknownRoute(route)) if route == "/unknown/path"
+        ));
+        assert!(matches!(
+            matching_route_paths("/invalid"),
+            Err(Error::UnknownRoute(route)) if route == "/invalid"
+        ));
     }
 
     #[test]
@@ -1014,7 +1128,31 @@ mod tests {
         )));
 
         // But there is no RoutePath::MintQuote without a payment method
-        // So the list should only contain 2 items (bolt11 and bolt12), not a bare "/v1/mint/quote"
-        assert_eq!(paths.len(), 2);
+        // So the list should only contain bolt11/bolt12 and the wildcard policy,
+        // not a bare "/v1/mint/quote".
+        assert_eq!(paths.len(), 3);
+        assert!(paths.contains(&RoutePath::Wildcard("/v1/mint/quote/".to_string())));
+    }
+
+    #[test]
+    fn test_wildcard_protects_custom_payment_methods() {
+        let paths_star = matching_route_paths("/v1/*").unwrap();
+        let paths_mint = matching_route_paths("/v1/mint/*").unwrap();
+
+        let custom_mint = RoutePath::Mint("paypal".to_string());
+        let custom_mint_quote = RoutePath::MintQuote("paypal".to_string());
+
+        assert!(paths_star
+            .iter()
+            .any(|path| path.match_specificity(&custom_mint).is_some()));
+        assert!(paths_star
+            .iter()
+            .any(|path| path.match_specificity(&custom_mint_quote).is_some()));
+        assert!(paths_mint
+            .iter()
+            .any(|path| path.match_specificity(&custom_mint).is_some()));
+        assert!(paths_mint
+            .iter()
+            .any(|path| path.match_specificity(&custom_mint_quote).is_some()));
     }
 }

--- a/crates/cashu/src/nuts/auth/nut22.rs
+++ b/crates/cashu/src/nuts/auth/nut22.rs
@@ -369,7 +369,7 @@ mod tests {
         let settings: Settings = serde_json::from_str(json).unwrap();
 
         assert_eq!(settings.bat_max_mint, 5);
-        assert_eq!(settings.protected_endpoints.len(), 5); // 4 mint paths + 1 swap path
+        assert_eq!(settings.protected_endpoints.len(), 6); // 4 mint paths + wildcard + 1 swap path
 
         let expected_protected: HashSet<ProtectedEndpoint> = HashSet::from_iter(vec![
             ProtectedEndpoint::new(Method::Post, RoutePath::Swap),
@@ -389,6 +389,7 @@ mod tests {
                 Method::Get,
                 RoutePath::Mint(PaymentMethod::Known(KnownMethod::Bolt12).to_string()),
             ),
+            ProtectedEndpoint::new(Method::Get, RoutePath::Wildcard("/v1/mint/".to_string())),
         ]);
 
         let deserialized_protected = settings.protected_endpoints.into_iter().collect();
@@ -413,6 +414,22 @@ mod tests {
     }
 
     #[test]
+    fn test_settings_deserialize_unknown_exact_path() {
+        let json = r#"{
+            "bat_max_mint": 5,
+            "protected_endpoints": [
+                {
+                    "method": "POST",
+                    "path": "/v1/swp"
+                }
+            ]
+        }"#;
+
+        let result = serde_json::from_str::<Settings>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_settings_deserialize_all_paths() {
         let json = r#"{
             "bat_max_mint": 5,
@@ -427,7 +444,7 @@ mod tests {
         let settings: Settings = serde_json::from_str(json).unwrap();
         assert_eq!(
             settings.protected_endpoints.len(),
-            RoutePath::all_known_paths().len()
+            RoutePath::all_known_paths().len() + 1
         );
     }
 }

--- a/crates/cashu/src/nuts/nut03.rs
+++ b/crates/cashu/src/nuts/nut03.rs
@@ -204,4 +204,45 @@ mod tests {
         assert!(!rebuilt.inputs().is_empty());
         assert!(!rebuilt.outputs().is_empty());
     }
+
+    #[test]
+    fn test_swap_request_outputs_mut_updates_outputs() {
+        let mut req: SwapRequest = serde_json::from_str(SWAP_REQUEST_JSON).unwrap();
+        let output = req.outputs()[0].clone();
+
+        req.outputs_mut().push(output);
+
+        assert_eq!(req.outputs().len(), 2);
+    }
+
+    #[test]
+    fn test_swap_request_amounts() {
+        let req: SwapRequest = serde_json::from_str(SWAP_REQUEST_JSON).unwrap();
+
+        assert_eq!(req.input_amount().unwrap(), Amount::from(6));
+        assert_eq!(req.output_amount().unwrap(), Amount::from(2));
+    }
+
+    #[test]
+    fn test_swap_response_promises_amount() {
+        let response: SwapResponse = serde_json::from_str(
+            r#"{
+                "signatures": [
+                    {
+                        "amount": 8,
+                        "id": "00bfa73302d12ffd",
+                        "C_": "02c97ee3d1db41cf0a3ddb601724be8711a032950811bf326f8219c50c4808d3cd"
+                    },
+                    {
+                        "amount": 4,
+                        "id": "00bfa73302d12ffd",
+                        "C_": "038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(response.promises_amount().unwrap(), Amount::from(12));
+    }
 }

--- a/crates/cashu/src/nuts/nut04.rs
+++ b/crates/cashu/src/nuts/nut04.rs
@@ -102,7 +102,7 @@ impl Serialize for MintMethodSettings {
     where
         S: Serializer,
     {
-        let mut num_fields = 3; // method and unit are always present
+        let mut num_fields = 2; // method and unit are always present
         if self.min_amount.is_some() {
             num_fields += 1;
         }
@@ -430,10 +430,298 @@ impl From<MintQuoteCustomResponse<QuoteId>> for MintQuoteCustomResponse<String> 
 }
 #[cfg(test)]
 mod tests {
+    use std::fmt;
+
+    use serde::ser::{Impossible, SerializeStruct, Serializer};
     use serde_json::{from_str, json, to_string};
 
     use super::*;
     use crate::nut00::KnownMethod;
+
+    #[derive(Debug)]
+    struct FieldCountError(String);
+
+    impl fmt::Display for FieldCountError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl std::error::Error for FieldCountError {}
+
+    impl serde::ser::Error for FieldCountError {
+        fn custom<T>(msg: T) -> Self
+        where
+            T: fmt::Display,
+        {
+            Self(msg.to_string())
+        }
+    }
+
+    struct FieldCountSerializer;
+
+    struct FieldCountStruct {
+        declared: usize,
+        actual: usize,
+    }
+
+    impl Serializer for FieldCountSerializer {
+        type Ok = ();
+        type Error = FieldCountError;
+        type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+        type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+        type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+        type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+        type SerializeMap = Impossible<Self::Ok, Self::Error>;
+        type SerializeStruct = FieldCountStruct;
+        type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+        fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported bool".to_string()))
+        }
+
+        fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported i8".to_string()))
+        }
+
+        fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported i16".to_string()))
+        }
+
+        fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported i32".to_string()))
+        }
+
+        fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported i64".to_string()))
+        }
+
+        fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported u8".to_string()))
+        }
+
+        fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported u16".to_string()))
+        }
+
+        fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported u32".to_string()))
+        }
+
+        fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported u64".to_string()))
+        }
+
+        fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported f32".to_string()))
+        }
+
+        fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported f64".to_string()))
+        }
+
+        fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported char".to_string()))
+        }
+
+        fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported str".to_string()))
+        }
+
+        fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported bytes".to_string()))
+        }
+
+        fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported none".to_string()))
+        }
+
+        fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            Err(FieldCountError("unsupported some".to_string()))
+        }
+
+        fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported unit".to_string()))
+        }
+
+        fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported unit struct".to_string()))
+        }
+
+        fn serialize_unit_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+        ) -> Result<Self::Ok, Self::Error> {
+            Err(FieldCountError("unsupported unit variant".to_string()))
+        }
+
+        fn serialize_newtype_struct<T>(
+            self,
+            _name: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            Err(FieldCountError("unsupported newtype struct".to_string()))
+        }
+
+        fn serialize_newtype_variant<T>(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+            _value: &T,
+        ) -> Result<Self::Ok, Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            Err(FieldCountError("unsupported newtype variant".to_string()))
+        }
+
+        fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+            Err(FieldCountError("unsupported seq".to_string()))
+        }
+
+        fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+            Err(FieldCountError("unsupported tuple".to_string()))
+        }
+
+        fn serialize_tuple_struct(
+            self,
+            _name: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+            Err(FieldCountError("unsupported tuple struct".to_string()))
+        }
+
+        fn serialize_tuple_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+            Err(FieldCountError("unsupported tuple variant".to_string()))
+        }
+
+        fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+            Err(FieldCountError("unsupported map".to_string()))
+        }
+
+        fn serialize_struct(
+            self,
+            _name: &'static str,
+            len: usize,
+        ) -> Result<Self::SerializeStruct, Self::Error> {
+            Ok(FieldCountStruct {
+                declared: len,
+                actual: 0,
+            })
+        }
+
+        fn serialize_struct_variant(
+            self,
+            _name: &'static str,
+            _variant_index: u32,
+            _variant: &'static str,
+            _len: usize,
+        ) -> Result<Self::SerializeStructVariant, Self::Error> {
+            Err(FieldCountError("unsupported struct variant".to_string()))
+        }
+    }
+
+    impl SerializeStruct for FieldCountStruct {
+        type Ok = ();
+        type Error = FieldCountError;
+
+        fn serialize_field<T>(&mut self, _key: &'static str, _value: &T) -> Result<(), Self::Error>
+        where
+            T: ?Sized + Serialize,
+        {
+            self.actual += 1;
+            Ok(())
+        }
+
+        fn end(self) -> Result<Self::Ok, Self::Error> {
+            if self.actual == self.declared {
+                Ok(())
+            } else {
+                Err(FieldCountError(format!(
+                    "declared {} fields but serialized {}",
+                    self.declared, self.actual
+                )))
+            }
+        }
+    }
+
+    fn assert_mint_method_settings_field_count(settings: &MintMethodSettings) {
+        settings.serialize(FieldCountSerializer).unwrap();
+    }
+
+    #[test]
+    fn test_mint_request_total_amount() {
+        let request: MintRequest<String> = from_str(
+            r#"{
+                "quote": "quote-id",
+                "outputs": [
+                    {
+                        "amount": 2,
+                        "id": "00bfa73302d12ffd",
+                        "B_": "038ec853d65ae1b79b5cdbc2774150b2cb288d6d26e12958a16fb33c32d9a86c39"
+                    },
+                    {
+                        "amount": 4,
+                        "id": "00bfa73302d12ffd",
+                        "B_": "02c97ee3d1db41cf0a3ddb601724be8711a032950811bf326f8219c50c4808d3cd"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(request.total_amount().unwrap(), Amount::from(6));
+    }
+
+    #[test]
+    fn test_mint_method_settings_serialize_field_count() {
+        assert_mint_method_settings_field_count(&MintMethodSettings {
+            method: PaymentMethod::Known(KnownMethod::Bolt11),
+            unit: CurrencyUnit::Sat,
+            min_amount: Some(Amount::from(1)),
+            max_amount: Some(Amount::from(1000)),
+            options: Some(MintMethodOptions::Bolt11 { description: true }),
+        });
+
+        assert_mint_method_settings_field_count(&MintMethodSettings {
+            method: PaymentMethod::Known(KnownMethod::Bolt11),
+            unit: CurrencyUnit::Sat,
+            min_amount: Some(Amount::from(1)),
+            max_amount: None,
+            options: None,
+        });
+
+        assert_mint_method_settings_field_count(&MintMethodSettings {
+            method: PaymentMethod::Known(KnownMethod::Bolt11),
+            unit: CurrencyUnit::Sat,
+            min_amount: None,
+            max_amount: Some(Amount::from(1000)),
+            options: None,
+        });
+
+        assert_mint_method_settings_field_count(&MintMethodSettings {
+            method: PaymentMethod::Known(KnownMethod::Bolt11),
+            unit: CurrencyUnit::Sat,
+            min_amount: None,
+            max_amount: None,
+            options: Some(MintMethodOptions::Bolt11 { description: true }),
+        });
+    }
 
     #[test]
     fn test_mint_method_settings_top_level_description() {

--- a/crates/cashu/src/nuts/nut10/spending_conditions.rs
+++ b/crates/cashu/src/nuts/nut10/spending_conditions.rs
@@ -110,7 +110,9 @@ impl TryFrom<Nut10Secret> for SpendingConditions {
                 conditions: secret
                     .secret_data()
                     .tags()
-                    .and_then(|t| t.clone().try_into().ok()),
+                    .cloned()
+                    .map(Conditions::try_from)
+                    .transpose()?,
             }),
             Kind::HTLC => Ok(Self::HTLCConditions {
                 data: Sha256Hash::from_str(secret.secret_data().data())
@@ -118,7 +120,9 @@ impl TryFrom<Nut10Secret> for SpendingConditions {
                 conditions: secret
                     .secret_data()
                     .tags()
-                    .and_then(|t| t.clone().try_into().ok()),
+                    .cloned()
+                    .map(Conditions::try_from)
+                    .transpose()?,
             }),
         }
     }
@@ -142,6 +146,7 @@ impl From<SpendingConditions> for super::Secret {
 impl TryFrom<SpendingConditions> for Secret {
     type Error = Error;
     fn try_from(conditions: SpendingConditions) -> Result<Secret, Self::Error> {
+        conditions.validate()?;
         let secret: Nut10Secret = conditions.into();
         Secret::try_from(secret)
     }
@@ -176,6 +181,61 @@ pub struct Conditions {
 }
 
 impl Conditions {
+    fn validate(&self, primary_key_count: u64) -> Result<(), Error> {
+        if let Some(n) = self.num_sigs {
+            if n == 0 {
+                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+            }
+
+            let available_keys =
+                primary_key_count + self.pubkeys.as_ref().map(Vec::len).unwrap_or(0) as u64;
+            if n > available_keys {
+                return Err(Error::NUT11(
+                    crate::nut11::Error::ImpossibleMultisigConfiguration {
+                        required: n,
+                        available: available_keys,
+                    },
+                ));
+            }
+        }
+
+        match (&self.refund_keys, self.num_sigs_refund) {
+            (Some(_), Some(0)) => {
+                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+            }
+            (Some(refund_keys), Some(required)) if required > refund_keys.len() as u64 => {
+                return Err(Error::NUT11(
+                    crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                        required,
+                        available: refund_keys.len() as u64,
+                    },
+                ));
+            }
+            (None, Some(0)) => {
+                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+            }
+            (None, Some(required)) => {
+                return Err(Error::NUT11(
+                    crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                        required,
+                        available: 0,
+                    },
+                ));
+            }
+            (Some(refund_keys), None) if refund_keys.is_empty() => {
+                return Err(Error::NUT11(
+                    crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                        required: 1,
+                        available: 0,
+                    },
+                ));
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
     /// Create new Spending [`Conditions`]
     pub fn new(
         locktime: Option<u64>,
@@ -192,46 +252,39 @@ impl Conditions {
             );
         }
 
-        if let Some(n) = num_sigs {
-            if n == 0 {
-                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
-            }
-            let available_keys = 1 + pubkeys.as_ref().map(Vec::len).unwrap_or(0);
-            if n > available_keys as u64 {
-                return Err(Error::NUT11(
-                    crate::nut11::Error::ImpossibleMultisigConfiguration {
-                        required: n,
-                        available: available_keys as u64,
-                    },
-                ));
-            }
-        }
-
-        if let Some(n) = num_sigs_refund {
-            if n == 0 {
-                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
-            }
-            let refund_key_count = refund_keys.as_ref().map(Vec::len).unwrap_or(0);
-            if n > refund_key_count as u64 {
-                return Err(Error::NUT11(
-                    crate::nut11::Error::ImpossibleMultisigConfiguration {
-                        required: n,
-                        available: refund_key_count as u64,
-                    },
-                ));
-            }
-        }
-
-        Ok(Self {
+        let conditions = Self {
             locktime,
             pubkeys,
             refund_keys,
             num_sigs,
             sig_flag: sig_flag.unwrap_or_default(),
             num_sigs_refund,
-        })
+        };
+        conditions.validate(1)?;
+
+        Ok(conditions)
     }
 }
+
+impl SpendingConditions {
+    fn validate(&self) -> Result<(), Error> {
+        match self {
+            Self::P2PKConditions { conditions, .. } => {
+                if let Some(conditions) = conditions {
+                    conditions.validate(1)?;
+                }
+            }
+            Self::HTLCConditions { conditions, .. } => {
+                if let Some(conditions) = conditions {
+                    conditions.validate(0)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 impl From<Conditions> for Vec<Vec<String>> {
     fn from(conditions: Conditions) -> Vec<Vec<String>> {
         let Conditions {
@@ -257,7 +310,7 @@ impl From<Conditions> for Vec<Vec<String>> {
             tags.push(Tag::NSigs(num_sigs).as_vec());
         }
 
-        if let Some(refund_keys) = refund_keys {
+        if let Some(refund_keys) = refund_keys.filter(|keys| !keys.is_empty()) {
             tags.push(Tag::Refund(refund_keys).as_vec())
         }
 
@@ -324,6 +377,25 @@ impl TryFrom<Vec<Vec<String>>> for Conditions {
             return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
         }
 
+        if let Some(refund_keys) = &refund_keys {
+            let required = num_sigs_refund.unwrap_or(1);
+            if required > refund_keys.len() as u64 {
+                return Err(Error::NUT11(
+                    crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                        required,
+                        available: refund_keys.len() as u64,
+                    },
+                ));
+            }
+        } else if let Some(required) = num_sigs_refund {
+            return Err(Error::NUT11(
+                crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                    required,
+                    available: 0,
+                },
+            ));
+        }
+
         Ok(Conditions {
             locktime,
             pubkeys,
@@ -374,5 +446,85 @@ mod tests {
             conditions.refund_keys,
             Some(vec![PublicKey::from_str(pk1).unwrap()])
         );
+    }
+
+    #[test]
+    fn test_empty_refund_tag_is_rejected() {
+        let tags = vec![
+            vec!["refund".to_string()],
+            vec!["sigflag".to_string(), "SIG_INPUTS".to_string()],
+        ];
+
+        let result = Conditions::try_from(tags);
+
+        assert!(matches!(
+            result,
+            Err(Error::NUT11(
+                crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                    required: 1,
+                    available: 0
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_empty_refund_keys_are_not_serialized() {
+        let conditions = Conditions {
+            locktime: Some(1),
+            pubkeys: None,
+            refund_keys: Some(vec![]),
+            num_sigs: None,
+            sig_flag: crate::SigFlag::default(),
+            num_sigs_refund: None,
+        };
+
+        let tags = Vec::<Vec<String>>::from(conditions);
+
+        assert!(!tags
+            .iter()
+            .any(|tag| tag.first() == Some(&"refund".to_string())));
+    }
+
+    #[test]
+    fn test_n_sigs_refund_without_refund_keys_is_rejected() {
+        let tags = vec![
+            vec!["n_sigs_refund".to_string(), "1".to_string()],
+            vec!["sigflag".to_string(), "SIG_INPUTS".to_string()],
+        ];
+
+        let result = Conditions::try_from(tags);
+
+        assert!(matches!(
+            result,
+            Err(Error::NUT11(
+                crate::nut11::Error::ImpossibleRefundMultisigConfiguration {
+                    required: 1,
+                    available: 0
+                }
+            ))
+        ));
+    }
+
+    #[test]
+    fn test_spending_conditions_try_from_propagates_invalid_tags() {
+        let pubkey = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+        let nut10_secret = Nut10Secret::new(
+            Kind::P2PK,
+            crate::nuts::nut10::SecretData::new(
+                pubkey.to_string(),
+                Some(vec![vec!["n_sigs".to_string(), "0".to_string()]]),
+            ),
+        );
+
+        let result = SpendingConditions::try_from(nut10_secret);
+
+        assert!(matches!(
+            result,
+            Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired))
+        ));
     }
 }

--- a/crates/cashu/src/nuts/nut10/spending_conditions.rs
+++ b/crates/cashu/src/nuts/nut10/spending_conditions.rs
@@ -193,6 +193,9 @@ impl Conditions {
         }
 
         if let Some(n) = num_sigs {
+            if n == 0 {
+                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+            }
             let available_keys = 1 + pubkeys.as_ref().map(Vec::len).unwrap_or(0);
             if n > available_keys as u64 {
                 return Err(Error::NUT11(
@@ -205,6 +208,9 @@ impl Conditions {
         }
 
         if let Some(n) = num_sigs_refund {
+            if n == 0 {
+                return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+            }
             let refund_key_count = refund_keys.as_ref().map(Vec::len).unwrap_or(0);
             if n > refund_key_count as u64 {
                 return Err(Error::NUT11(
@@ -309,6 +315,13 @@ impl TryFrom<Vec<Vec<String>>> for Conditions {
                 }
                 Tag::Custom(_, _) => {}
             }
+        }
+
+        if let Some(0) = num_sigs {
+            return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+        }
+        if let Some(0) = num_sigs_refund {
+            return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
         }
 
         Ok(Conditions {

--- a/crates/cashu/src/nuts/nut10/tag.rs
+++ b/crates/cashu/src/nuts/nut10/tag.rs
@@ -116,12 +116,17 @@ where
             TagKind::SigFlag => Ok(Tag::SigFlag(SigFlag::from_str(
                 tag.get(1).ok_or(Error::TagValueNotFound)?.as_ref(),
             )?)),
-            TagKind::NSigs => Ok(Tag::NSigs(
-                tag.get(1)
+            TagKind::NSigs => {
+                let sigs = tag
+                    .get(1)
                     .ok_or(Error::TagValueNotFound)?
                     .as_ref()
-                    .parse()?,
-            )),
+                    .parse()?;
+                if sigs == 0 {
+                    return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+                }
+                Ok(Tag::NSigs(sigs))
+            }
             TagKind::Locktime => Ok(Tag::LockTime(
                 tag.get(1)
                     .ok_or(Error::TagValueNotFound)?
@@ -146,12 +151,17 @@ where
 
                 Ok(Self::PubKeys(pubkeys))
             }
-            TagKind::NSigsRefund => Ok(Tag::NSigsRefund(
-                tag.get(1)
+            TagKind::NSigsRefund => {
+                let sigs = tag
+                    .get(1)
                     .ok_or(Error::TagValueNotFound)?
                     .as_ref()
-                    .parse()?,
-            )),
+                    .parse()?;
+                if sigs == 0 {
+                    return Err(Error::NUT11(crate::nut11::Error::ZeroSignaturesRequired));
+                }
+                Ok(Tag::NSigsRefund(sigs))
+            }
             TagKind::Custom(name) => {
                 let tags = tag
                     .iter()

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -82,6 +82,9 @@ pub enum Error {
     /// SIG_ALL not supported in this context
     #[error("SIG_ALL proofs must be verified using a different method")]
     SigAllNotSupportedHere,
+    /// Number of required signatures cannot be zero
+    #[error("Number of required signatures must be 1 or greater")]
+    ZeroSignaturesRequired,
     /// Serde Json error
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::Error),
@@ -2263,5 +2266,165 @@ mod tests {
             None,
         );
         assert!(result.is_err(), "4-of-3 should be impossible");
+    }
+
+    #[test]
+    fn test_p2pk_num_sigs_zero_bypasses_signature_requirement() {
+        // n_sigs=0 makes verify_p2pk() evaluate `valid_sig_count >= required_sigs`
+        // as `0 >= 0` which is trivially true. An empty P2PKWitness therefore
+        // passes verification with no cryptographic check at all.
+        //
+        // Per bkb's record of NUT-11: n_sigs must be "a positive integer".
+        // n_sigs=0 is out-of-spec and produces an anyone-can-spend P2PK proof.
+        //
+        // FAILS on HEAD (verify_p2pk returns Ok). PASSES once fixed.
+        let data_pubkey = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+
+        let conditions = Conditions {
+            locktime: None,
+            pubkeys: None,
+            refund_keys: None,
+            num_sigs: Some(0), // invalid: not a positive integer per NUT-11
+            sig_flag: SigFlag::SigInputs,
+            num_sigs_refund: None,
+        };
+
+        // Creating the secret correctly
+        let secret: Secret = SpendingConditions::new_p2pk(data_pubkey, Some(conditions))
+            .try_into()
+            .unwrap();
+
+        let proof = Proof {
+            keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
+            amount: Amount::ZERO,
+            secret,
+            c: data_pubkey,
+            witness: Some(Witness::P2PKWitness(P2PKWitness { signatures: vec![] })),
+            dleq: None,
+            p2pk_e: None,
+        };
+
+        // FAILS on HEAD: required_sigs=0 makes the comparison trivially true
+        // for any witness, including an empty one with no signatures.
+        assert!(
+            proof.verify_p2pk().is_err(),
+            "P2PK with num_sigs=0 must not be spendable with an empty witness"
+        );
+    }
+
+    #[test]
+    fn test_sig_all_p2pk_nsigs_zero_bypasses_sig_check() {
+        let data_pubkey = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+        let extra_pubkey = PublicKey::from_str(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+        )
+        .unwrap();
+
+        // Note: We bypass Conditions::new() by constructing it directly,
+        // to test the low-level verify routine. But because we implemented
+        // ZeroSignaturesRequired inside TryFrom for Conditions too,
+        // Secret::try_into() will fail on building the conditions!
+        // To make the test actually exercise verify_sig_all_p2pk on a "bad" Secret,
+        // we have to assert that either creation fails or verify_sig_all_p2pk fails.
+        // Given our fix prevents creation entirely, the test should check that.
+        let nut10_secret = Nut10Secret::new(
+            crate::nuts::nut10::Kind::P2PK,
+            crate::nuts::nut10::SecretData::new(
+                data_pubkey.to_string(),
+                Some(vec![
+                    vec!["pubkeys".to_string(), extra_pubkey.to_string()],
+                    vec!["n_sigs".to_string(), "0".to_string()],
+                    vec!["sigflag".to_string(), "SIG_ALL".to_string()],
+                ]),
+            ),
+        );
+        let conditions_res = crate::nuts::nut10::Conditions::try_from(
+            nut10_secret.secret_data().tags().cloned().unwrap(),
+        );
+        assert!(
+            conditions_res.is_err(),
+            "Conditions should fail to parse due to n_sigs=0"
+        );
+    }
+
+    #[test]
+    fn test_refund_path_num_sigs_refund_zero_bypasses_signature_check() {
+        // When n_sigs_refund=Some(0) and refund_keys are present,
+        // get_pubkeys_and_required_sigs sets required_sigs=0 for the RefundPath.
+        // In verify_p2pk the guard
+        //   if refund_path.required_sigs == 0 { return Ok(()); }
+        // fires once locktime has passed, letting anyone spend with an empty
+        // witness and no valid refund-key signature.
+        //
+        // FAILS on HEAD (verify_p2pk returns Ok). PASSES once the fix is applied.
+
+        let data_pubkey = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+
+        let refund_pubkey = PublicKey::from_str(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+        )
+        .unwrap();
+
+        let nut10_secret = Nut10Secret::new(
+            crate::nuts::nut10::Kind::P2PK,
+            crate::nuts::nut10::SecretData::new(
+                data_pubkey.to_string(),
+                Some(vec![
+                    vec!["locktime".to_string(), "1".to_string()],
+                    vec!["refund".to_string(), refund_pubkey.to_string()],
+                    vec!["n_sigs".to_string(), "1".to_string()],
+                    vec!["n_sigs_refund".to_string(), "0".to_string()],
+                ]),
+            ),
+        );
+        let conditions_res = crate::nuts::nut10::Conditions::try_from(
+            nut10_secret.secret_data().tags().cloned().unwrap(),
+        );
+        assert!(
+            conditions_res.is_err(),
+            "Conditions should fail to parse due to n_sigs=0"
+        );
+    }
+
+    #[test]
+    fn test_sig_all_p2pk_nsigs_refund_zero_bypasses_refund_sig_check() {
+        let data_pubkey = PublicKey::from_str(
+            "026562efcfadc8e86d44da6a8adf80633d974302e62c850774db1fb36ff4cc7198",
+        )
+        .unwrap();
+        let refund_pubkey = PublicKey::from_str(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+        )
+        .unwrap();
+
+        let nut10_secret = Nut10Secret::new(
+            crate::nuts::nut10::Kind::P2PK,
+            crate::nuts::nut10::SecretData::new(
+                data_pubkey.to_string(),
+                Some(vec![
+                    vec!["locktime".to_string(), "1".to_string()],
+                    vec!["refund".to_string(), refund_pubkey.to_string()],
+                    vec!["n_sigs".to_string(), "1".to_string()],
+                    vec!["n_sigs_refund".to_string(), "0".to_string()],
+                    vec!["sigflag".to_string(), "SIG_ALL".to_string()],
+                ]),
+            ),
+        );
+        let conditions_res = crate::nuts::nut10::Conditions::try_from(
+            nut10_secret.secret_data().tags().cloned().unwrap(),
+        );
+        assert!(
+            conditions_res.is_err(),
+            "Conditions should fail to parse due to n_sigs_refund=0"
+        );
     }
 }

--- a/crates/cashu/src/nuts/nut11/mod.rs
+++ b/crates/cashu/src/nuts/nut11/mod.rs
@@ -2181,7 +2181,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                crate::nut10::Error::NUT11(Error::ImpossibleMultisigConfiguration {
+                crate::nut10::Error::NUT11(Error::ImpossibleRefundMultisigConfiguration {
                     required: 3,
                     available: 1,
                 })
@@ -2225,7 +2225,7 @@ mod tests {
         assert!(
             matches!(
                 err,
-                crate::nut10::Error::NUT11(Error::ImpossibleMultisigConfiguration {
+                crate::nut10::Error::NUT11(Error::ImpossibleRefundMultisigConfiguration {
                     required: 1,
                     available: 0,
                 })
@@ -2292,27 +2292,13 @@ mod tests {
             num_sigs_refund: None,
         };
 
-        // Creating the secret correctly
-        let secret: Secret = SpendingConditions::new_p2pk(data_pubkey, Some(conditions))
-            .try_into()
-            .unwrap();
+        let result: Result<Secret, _> =
+            SpendingConditions::new_p2pk(data_pubkey, Some(conditions)).try_into();
 
-        let proof = Proof {
-            keyset_id: Id::from_str("009a1f293253e41e").unwrap(),
-            amount: Amount::ZERO,
-            secret,
-            c: data_pubkey,
-            witness: Some(Witness::P2PKWitness(P2PKWitness { signatures: vec![] })),
-            dleq: None,
-            p2pk_e: None,
-        };
-
-        // FAILS on HEAD: required_sigs=0 makes the comparison trivially true
-        // for any witness, including an empty one with no signatures.
-        assert!(
-            proof.verify_p2pk().is_err(),
-            "P2PK with num_sigs=0 must not be spendable with an empty witness"
-        );
+        assert!(matches!(
+            result,
+            Err(crate::nut10::Error::NUT11(Error::ZeroSignaturesRequired))
+        ));
     }
 
     #[test]

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -748,4 +748,84 @@ mod tests {
             "Should fail when using refund path with refund keys but no signature"
         );
     }
+
+    #[test]
+    fn test_htlc_generated_empty_refund_keys_are_omitted() {
+        use crate::nuts::nut10::Conditions;
+
+        let preimage_bytes = [42u8; 32];
+        let hash = Sha256Hash::hash(&preimage_bytes);
+        let hash_str = hash.to_string();
+
+        let conditions = Conditions {
+            locktime: Some(1),
+            pubkeys: None,
+            refund_keys: Some(vec![]),
+            num_sigs: None,
+            sig_flag: crate::nuts::nut11::SigFlag::default(),
+            num_sigs_refund: None,
+        };
+
+        let nut10_secret =
+            Nut10Secret::new(Kind::HTLC, SecretData::new(hash_str, Some(conditions)));
+        let secret: SecretString = nut10_secret.try_into().unwrap();
+
+        let htlc_witness = HTLCWitness {
+            preimage: hex::encode([0xffu8; 32]),
+            signatures: None,
+        };
+
+        let proof = Proof {
+            amount: crate::Amount::from(1),
+            keyset_id: crate::nuts::nut02::Id::from_str("00deadbeef123456").unwrap(),
+            secret,
+            c: crate::nuts::nut01::PublicKey::from_hex(
+                "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+            )
+            .unwrap(),
+            witness: Some(Witness::HTLCWitness(htlc_witness)),
+            dleq: None,
+            p2pk_e: None,
+        };
+
+        assert!(proof.verify_htlc().is_ok());
+    }
+
+    #[test]
+    fn test_htlc_empty_refund_tag_is_rejected() {
+        let preimage_bytes = [42u8; 32];
+        let hash = Sha256Hash::hash(&preimage_bytes);
+        let hash_str = hash.to_string();
+
+        let tags = vec![
+            vec!["locktime".to_string(), "1".to_string()],
+            vec!["refund".to_string()],
+        ];
+
+        let nut10_secret = Nut10Secret::new(Kind::HTLC, SecretData::new(hash_str, Some(tags)));
+        let secret: SecretString = nut10_secret.try_into().unwrap();
+
+        let htlc_witness = HTLCWitness {
+            preimage: hex::encode([0xffu8; 32]),
+            signatures: None,
+        };
+
+        let proof = Proof {
+            amount: crate::Amount::from(1),
+            keyset_id: crate::nuts::nut02::Id::from_str("00deadbeef123456").unwrap(),
+            secret,
+            c: crate::nuts::nut01::PublicKey::from_hex(
+                "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+            )
+            .unwrap(),
+            witness: Some(Witness::HTLCWitness(htlc_witness)),
+            dleq: None,
+            p2pk_e: None,
+        };
+
+        assert!(matches!(
+            proof.verify_htlc(),
+            Err(Error::SpendConditionsNotMet)
+        ));
+    }
 }

--- a/crates/cashu/src/nuts/nut14/mod.rs
+++ b/crates/cashu/src/nuts/nut14/mod.rs
@@ -527,6 +527,63 @@ mod tests {
         assert!(matches!(result.unwrap_err(), Error::InvalidHash));
     }
 
+    #[test]
+    fn test_htlc_num_sigs_zero_bypasses_signature_requirement() {
+        let pubkey = crate::nuts::nut01::PublicKey::from_hex(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+        )
+        .unwrap();
+
+        let preimage_bytes = [42u8; 32];
+        let hash = Sha256Hash::hash(&preimage_bytes);
+        let hash_str = hash.to_string();
+
+        let tags = vec![
+            vec!["pubkeys".to_string(), pubkey.to_string()],
+            vec!["n_sigs".to_string(), "0".to_string()],
+        ];
+
+        let nut10_secret = Nut10Secret::new(Kind::HTLC, SecretData::new(hash_str, Some(tags)));
+        // Since we patched deserialization itself (TryFrom<Secret>), let's verify that
+        // extracting the conditions out of a constructed secret will error
+        let conditions_res = crate::nuts::nut10::Conditions::try_from(
+            nut10_secret.secret_data().tags().cloned().unwrap(),
+        );
+        assert!(
+            conditions_res.is_err(),
+            "Conditions should fail to parse due to n_sigs=0"
+        );
+    }
+
+    #[test]
+    fn test_verify_sig_all_htlc_nsigs_zero_bypasses_sig_check() {
+        let preimage_bytes = [42u8; 32];
+        let hash = Sha256Hash::hash(&preimage_bytes);
+        let hash_str = hash.to_string();
+
+        let required_pubkey = crate::nuts::nut01::PublicKey::from_hex(
+            "02a9acc1e48c25eeeb9289b5031cc57da9fe72f3fe2861d264bdc074209b107ba2",
+        )
+        .unwrap();
+
+        // SIG_ALL HTLC with pubkeys but n_sigs=0
+        let tags = vec![
+            vec!["pubkeys".to_string(), required_pubkey.to_string()],
+            vec!["n_sigs".to_string(), "0".to_string()],
+            vec!["sigflag".to_string(), "SIG_ALL".to_string()],
+        ];
+
+        let nut10_secret = Nut10Secret::new(Kind::HTLC, SecretData::new(hash_str, Some(tags)));
+
+        let conditions_res = crate::nuts::nut10::Conditions::try_from(
+            nut10_secret.secret_data().tags().cloned().unwrap(),
+        );
+        assert!(
+            conditions_res.is_err(),
+            "Conditions should fail to parse due to n_sigs=0"
+        );
+    }
+
     /// Tests that verify_htlc correctly rejects an HTLC with the wrong witness type.
     ///
     /// This test ensures that the verification function checks that the witness is

--- a/crates/cdk-common/src/error.rs
+++ b/crates/cdk-common/src/error.rs
@@ -207,6 +207,9 @@ pub enum Error {
     /// Inactive Keyset
     #[error("Inactive Keyset")]
     InactiveKeyset,
+    /// Keyset has expired
+    #[error("Keyset has expired")]
+    ExpiredKeyset,
     /// Transaction unbalanced
     #[error("Inputs: `{0}`, Outputs: `{1}`, Expected Fee: `{2}`")]
     TransactionUnbalanced(u64, u64, u64),
@@ -574,6 +577,7 @@ impl Error {
             | Self::UnknownKeySet
             | Self::BlindedMessageAlreadySigned
             | Self::InactiveKeyset
+            | Self::ExpiredKeyset
             | Self::TransactionUnbalanced(_, _, _)
             | Self::DuplicateInputs
             | Self::DuplicateOutputs
@@ -879,6 +883,10 @@ impl From<Error> for ErrorResponse {
                 code: ErrorCode::KeysetInactive,
                 detail: err.to_string(),
             },
+            Error::ExpiredKeyset => ErrorResponse {
+                code: ErrorCode::KeysetExpired,
+                detail: err.to_string(),
+            },
             Error::AmountLessNotAllowed => ErrorResponse {
                 code: ErrorCode::AmountlessInvoiceNotSupported,
                 detail: err.to_string(),
@@ -1065,6 +1073,7 @@ impl From<ErrorResponse> for Error {
             // 12xxx - Keyset errors
             ErrorCode::KeysetNotFound => Self::UnknownKeySet,
             ErrorCode::KeysetInactive => Self::InactiveKeyset,
+            ErrorCode::KeysetExpired => Self::ExpiredKeyset,
             // 20xxx - Quote/Payment errors
             ErrorCode::QuoteNotPaid => Self::UnpaidQuote,
             ErrorCode::TokensAlreadyIssued => Self::IssuedQuote,
@@ -1132,6 +1141,8 @@ pub enum ErrorCode {
     KeysetNotFound,
     /// Keyset is inactive, cannot sign messages (12002)
     KeysetInactive,
+    /// Keyset expired (12003)
+    KeysetExpired,
 
     // 20xxx - Quote/Payment errors
     /// Quote request is not paid (20001)
@@ -1201,6 +1212,7 @@ impl ErrorCode {
             // 12xxx - Keyset errors
             12001 => Self::KeysetNotFound,
             12002 => Self::KeysetInactive,
+            12003 => Self::KeysetExpired,
             // 20xxx - Quote/Payment errors
             20001 => Self::QuoteNotPaid,
             20002 => Self::TokensAlreadyIssued,
@@ -1247,6 +1259,7 @@ impl ErrorCode {
             // 12xxx - Keyset errors
             Self::KeysetNotFound => 12001,
             Self::KeysetInactive => 12002,
+            Self::KeysetExpired => 12003,
             // 20xxx - Quote/Payment errors
             Self::QuoteNotPaid => 20001,
             Self::TokensAlreadyIssued => 20002,

--- a/crates/cdk-common/src/mint.rs
+++ b/crates/cdk-common/src/mint.rs
@@ -1019,6 +1019,13 @@ pub struct MintKeySetInfo {
     pub issuer_version: Option<IssuerVersion>,
 }
 
+impl MintKeySetInfo {
+    /// Returns true if `final_expiry` is set and strictly in the past.
+    pub fn is_expired(&self) -> bool {
+        self.final_expiry.is_some_and(|expiry| expiry < unix_time())
+    }
+}
+
 /// Default fee
 pub fn default_fee() -> u64 {
     0
@@ -1375,5 +1382,52 @@ mod tests {
 
         assert_eq!(response.quote, melt_quote.id);
         assert_eq!(response.request, None);
+    }
+
+    fn dummy_mint_keyset_info(final_expiry: Option<u64>) -> MintKeySetInfo {
+        use std::str::FromStr;
+        MintKeySetInfo {
+            id: Id::from_str("009a1f293253e41e").unwrap(),
+            unit: CurrencyUnit::Sat,
+            active: true,
+            valid_from: 0,
+            derivation_path: "m/0'/0'/0'".parse().unwrap(),
+            derivation_path_index: Some(0),
+            amounts: vec![1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+            input_fee_ppk: 0,
+            final_expiry,
+            issuer_version: None,
+        }
+    }
+
+    #[test]
+    fn test_is_expired_none() {
+        let info = dummy_mint_keyset_info(None);
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_far_future() {
+        let info = dummy_mint_keyset_info(Some(unix_time() + 1_000_000));
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_exactly_now_is_not_expired() {
+        // strict less-than: expiry == now is not yet expired
+        let info = dummy_mint_keyset_info(Some(unix_time()));
+        assert!(!info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_one_second_ago() {
+        let info = dummy_mint_keyset_info(Some(unix_time() - 1));
+        assert!(info.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_zero() {
+        let info = dummy_mint_keyset_info(Some(0));
+        assert!(info.is_expired());
     }
 }

--- a/crates/cdk-ffi/src/bip321.rs
+++ b/crates/cdk-ffi/src/bip321.rs
@@ -106,7 +106,7 @@ mod tests {
     const TEST_BOLT11: &str = "lnbc100n1ptest";
 
     fn assert_uri_prefix(uri: &str) {
-        assert!(uri.starts_with("bitcoin:?"));
+        assert!(uri.starts_with("BITCOIN:?"));
     }
 
     #[test]
@@ -118,8 +118,8 @@ mod tests {
         );
 
         assert_uri_prefix(&uri);
-        assert!(uri.contains(&format!("creq={TEST_CREQ}")));
-        assert!(uri.contains(&format!("lightning={TEST_BOLT11}")));
+        assert!(uri.contains(&format!("CREQ={TEST_CREQ}")));
+        assert!(uri.contains(&format!("LIGHTNING={}", TEST_BOLT11.to_ascii_uppercase())));
     }
 
     #[test]
@@ -127,9 +127,9 @@ mod tests {
         let uri = create_bip321_uri(Some(TEST_CREQ.to_string()), None, None);
 
         assert_uri_prefix(&uri);
-        assert!(uri.contains("creq="));
-        assert!(!uri.contains("lightning="));
-        assert!(!uri.contains("lno="));
+        assert!(uri.contains("CREQ="));
+        assert!(!uri.contains("LIGHTNING="));
+        assert!(!uri.contains("LNO="));
     }
 
     #[test]
@@ -137,8 +137,8 @@ mod tests {
         let uri = create_bip321_uri(None, Some(TEST_BOLT11.to_string()), None);
 
         assert_uri_prefix(&uri);
-        assert!(uri.contains(&format!("lightning={TEST_BOLT11}")));
-        assert!(!uri.contains("creq="));
+        assert!(uri.contains(&format!("LIGHTNING={}", TEST_BOLT11.to_ascii_uppercase())));
+        assert!(!uri.contains("CREQ="));
     }
 
     #[test]
@@ -152,14 +152,14 @@ mod tests {
         );
 
         assert_uri_prefix(&uri);
-        assert!(uri.contains("creq="));
-        assert!(uri.contains("lightning="));
-        assert!(uri.contains("lno="));
+        assert!(uri.contains("CREQ="));
+        assert!(uri.contains("LIGHTNING="));
+        assert!(uri.contains("LNO="));
     }
 
     #[test]
     fn test_create_bip321_uri_empty() {
         let uri = create_bip321_uri(None, None, None);
-        assert_eq!(uri, "bitcoin:");
+        assert_eq!(uri, "BITCOIN:");
     }
 }

--- a/crates/cdk-ffi/src/database.rs
+++ b/crates/cdk-ffi/src/database.rs
@@ -324,7 +324,10 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             .get_mint(ffi_mint_url)
             .await
             .map_err(|e| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-        Ok(result.map(Into::into))
+        result
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))
     }
 
     async fn get_mints(
@@ -344,7 +347,11 @@ impl CdkWalletDatabase<cdk::cdk_database::Error> for WalletDatabaseBridge {
             let cdk_url = ffi_mint_url
                 .try_into()
                 .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
-            cdk_result.insert(cdk_url, mint_info_opt.map(Into::into));
+            let cdk_mint_info = mint_info_opt
+                .map(TryInto::try_into)
+                .transpose()
+                .map_err(|e: FfiError| cdk::cdk_database::Error::Database(e.to_string().into()))?;
+            cdk_result.insert(cdk_url, cdk_mint_info);
         }
         Ok(cdk_result)
     }
@@ -1570,7 +1577,7 @@ where
         mint_info: Option<MintInfo>,
     ) -> Result<(), FfiError> {
         let cdk_mint_url = mint_url.try_into()?;
-        let cdk_mint_info = mint_info.map(Into::into);
+        let cdk_mint_info = mint_info.map(TryInto::try_into).transpose()?;
         self.inner
             .add_mint(cdk_mint_url, cdk_mint_info)
             .await

--- a/crates/cdk-ffi/src/lib.rs
+++ b/crates/cdk-ffi/src/lib.rs
@@ -14,6 +14,7 @@ pub mod logging;
 pub mod npubcash;
 #[cfg(feature = "postgres")]
 pub mod postgres;
+mod runtime;
 pub mod sqlite;
 #[cfg(feature = "supabase")]
 pub mod supabase;

--- a/crates/cdk-ffi/src/postgres.rs
+++ b/crates/cdk-ffi/src/postgres.rs
@@ -12,24 +12,8 @@ use crate::{
 #[derive(uniffi::Object)]
 pub struct WalletPostgresDatabase {
     inner: Arc<FfiWalletDatabaseWrapper<WalletPgDatabase, CdkDatabaseError>>,
-}
-
-// Keep a long-lived Tokio runtime for Postgres-created resources so that
-// background tasks (e.g., tokio-postgres connection drivers spawned during
-// construction) are not tied to a short-lived, ad-hoc runtime.
-#[cfg(feature = "postgres")]
-static PG_RUNTIME: once_cell::sync::OnceCell<tokio::runtime::Runtime> =
-    once_cell::sync::OnceCell::new();
-
-#[cfg(feature = "postgres")]
-fn pg_runtime() -> &'static tokio::runtime::Runtime {
-    PG_RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_name("cdk-ffi-pg")
-            .build()
-            .expect("failed to build pg runtime")
-    })
+    // Keep the runtime alive so Postgres background connection tasks survive.
+    _runtime: crate::runtime::RuntimeGuard,
 }
 
 #[uniffi::export]
@@ -41,19 +25,13 @@ impl WalletPostgresDatabase {
     #[cfg(feature = "postgres")]
     #[uniffi::constructor]
     pub fn new(url: String) -> Result<Arc<Self>, FfiError> {
-        let inner = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(
-                    async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await },
-                )
-            }),
-            // Important: use a process-long runtime so background connection tasks stay alive.
-            Err(_) => pg_runtime()
-                .block_on(async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await }),
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let inner = rt
+            .block_on(async move { cdk_postgres::new_wallet_pg_database(url.as_str()).await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(WalletPostgresDatabase {
             inner: FfiWalletDatabaseWrapper::new(inner),
+            _runtime: rt,
         }))
     }
 }

--- a/crates/cdk-ffi/src/runtime.rs
+++ b/crates/cdk-ffi/src/runtime.rs
@@ -1,0 +1,58 @@
+//! Lightweight runtime guard for FFI constructors.
+//!
+//! When called from an FFI language (Python, Swift, …) there may be no Tokio
+//! runtime on the current thread.  `RuntimeGuard` detects this and, if needed,
+//! lazily creates a multi-threaded runtime that lives as long as the guard.
+
+use std::future::Future;
+
+use tokio::runtime::{Handle, Runtime};
+
+/// Holds either a borrowed handle to an existing Tokio runtime or an owned
+/// runtime created on demand.  Dropping the guard shuts down the owned runtime
+/// (if any), so it should be kept alive as long as work may be spawned on it.
+pub(crate) struct RuntimeGuard {
+    _runtime: Option<Runtime>,
+    handle: Handle,
+}
+
+impl RuntimeGuard {
+    /// Create a new guard.
+    ///
+    /// * If a Tokio runtime is already running on this thread the guard simply
+    ///   captures its [`Handle`] (zero cost).
+    /// * Otherwise a new multi-threaded runtime is created and owned by the
+    ///   guard.
+    pub fn new() -> Result<Self, String> {
+        match Handle::try_current() {
+            Ok(handle) => Ok(Self {
+                _runtime: None,
+                handle,
+            }),
+            Err(_) => {
+                let rt = Runtime::new().map_err(|e| format!("Failed to create runtime: {e}"))?;
+                let handle = rt.handle().clone();
+                Ok(Self {
+                    _runtime: Some(rt),
+                    handle,
+                })
+            }
+        }
+    }
+
+    /// Run a future to completion on the runtime.
+    ///
+    /// When the guard wraps an *existing* runtime this uses
+    /// [`tokio::task::block_in_place`] so we don't starve the caller's worker
+    /// threads.  When it owns its own runtime it calls [`Handle::block_on`]
+    /// directly.
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        if self._runtime.is_some() {
+            // We own the runtime — safe to block_on directly.
+            self.handle.block_on(future)
+        } else {
+            // Running inside an external runtime — yield the worker thread.
+            tokio::task::block_in_place(|| self.handle.block_on(future))
+        }
+    }
+}

--- a/crates/cdk-ffi/src/sqlite.rs
+++ b/crates/cdk-ffi/src/sqlite.rs
@@ -13,6 +13,8 @@ use crate::{
 #[derive(uniffi::Object)]
 pub struct WalletSqliteDatabase {
     inner: Arc<FfiWalletDatabaseWrapper<CdkWalletSqliteDatabase, CdkDatabaseError>>,
+    // Keep the runtime alive so async pool operations work in FFI contexts.
+    _runtime: crate::runtime::RuntimeGuard,
 }
 
 #[uniffi::export]
@@ -20,41 +22,26 @@ impl WalletSqliteDatabase {
     /// Create a new WalletSqliteDatabase with the given work directory
     #[uniffi::constructor]
     pub fn new(file_path: String) -> Result<Arc<Self>, FfiError> {
-        let db = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle
-                    .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
-            }
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let db = rt
+            .block_on(async move { CdkWalletSqliteDatabase::new(file_path.as_str()).await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(Self {
             inner: FfiWalletDatabaseWrapper::new(db),
+            _runtime: rt,
         }))
     }
 
     /// Create an in-memory database
     #[uniffi::constructor]
     pub fn new_in_memory() -> Result<Arc<Self>, FfiError> {
-        let db = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move { cdk_sqlite::wallet::memory::empty().await })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move { cdk_sqlite::wallet::memory::empty().await })
-            }
-        }
-        .map_err(FfiError::internal)?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let db = rt
+            .block_on(async move { cdk_sqlite::wallet::memory::empty().await })
+            .map_err(FfiError::internal)?;
         Ok(Arc::new(Self {
             inner: FfiWalletDatabaseWrapper::new(db),
+            _runtime: rt,
         }))
     }
 }

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -2,7 +2,6 @@
 
 use std::str::FromStr;
 
-use cdk::nuts::nut00::{KnownMethod, PaymentMethod as NutPaymentMethod};
 use serde::{Deserialize, Serialize};
 
 use super::amount::{Amount, CurrencyUnit};
@@ -460,44 +459,10 @@ impl TryFrom<ProtectedEndpoint> for cdk::nuts::ProtectedEndpoint {
             }
         };
 
-        // Convert path string to RoutePath by matching against known paths
-        let route_path = match endpoint.path.as_str() {
-            "/v1/mint/quote/bolt11" => cdk::nuts::RoutePath::MintQuote(
-                NutPaymentMethod::Known(KnownMethod::Bolt11).to_string(),
-            ),
-            "/v1/mint/bolt11" => {
-                cdk::nuts::RoutePath::Mint(NutPaymentMethod::Known(KnownMethod::Bolt11).to_string())
-            }
-            "/v1/melt/quote/bolt11" => cdk::nuts::RoutePath::MeltQuote(
-                NutPaymentMethod::Known(KnownMethod::Bolt11).to_string(),
-            ),
-            "/v1/melt/bolt11" => {
-                cdk::nuts::RoutePath::Melt(NutPaymentMethod::Known(KnownMethod::Bolt11).to_string())
-            }
-            "/v1/swap" => cdk::nuts::RoutePath::Swap,
-            "/v1/ws" => cdk::nuts::RoutePath::Ws,
-            "/v1/checkstate" => cdk::nuts::RoutePath::Checkstate,
-            "/v1/restore" => cdk::nuts::RoutePath::Restore,
-            "/v1/auth/blind/mint" => cdk::nuts::RoutePath::MintBlindAuth,
-            "/v1/mint/quote/bolt12" => cdk::nuts::RoutePath::MintQuote(
-                NutPaymentMethod::Known(KnownMethod::Bolt12).to_string(),
-            ),
-            "/v1/mint/bolt12" => {
-                cdk::nuts::RoutePath::Mint(NutPaymentMethod::Known(KnownMethod::Bolt12).to_string())
-            }
-            "/v1/melt/quote/bolt12" => cdk::nuts::RoutePath::MeltQuote(
-                NutPaymentMethod::Known(KnownMethod::Bolt12).to_string(),
-            ),
-            "/v1/melt/bolt12" => {
-                cdk::nuts::RoutePath::Melt(NutPaymentMethod::Known(KnownMethod::Bolt12).to_string())
-            }
-            _ => {
-                return Err(FfiError::internal(format!(
-                    "Unknown route path: {}",
-                    endpoint.path
-                )))
-            }
-        };
+        let route_path = endpoint
+            .path
+            .parse()
+            .map_err(|err| FfiError::internal(format!("Unknown route path: {err}")))?;
 
         Ok(cdk::nuts::ProtectedEndpoint::new(method, route_path))
     }
@@ -724,6 +689,8 @@ pub fn encode_mint_info(info: MintInfo) -> Result<String, FfiError> {
 }
 #[cfg(test)]
 mod tests {
+    use cdk::nuts::nut00::{KnownMethod, PaymentMethod as NutPaymentMethod};
+
     use super::*;
 
     /// Helper function to create a sample cdk::nuts::Nuts for testing

--- a/crates/cdk-ffi/src/types/mint.rs
+++ b/crates/cdk-ffi/src/types/mint.rs
@@ -646,11 +646,11 @@ impl From<cdk::nuts::MintInfo> for MintInfo {
     }
 }
 
-impl From<MintInfo> for cdk::nuts::MintInfo {
-    fn from(info: MintInfo) -> Self {
-        // Convert FFI Nuts back to cdk::nuts::Nuts (best-effort)
-        let nuts_cdk: cdk::nuts::Nuts = info.nuts.clone().try_into().unwrap_or_default();
-        Self {
+impl TryFrom<MintInfo> for cdk::nuts::MintInfo {
+    type Error = FfiError;
+
+    fn try_from(info: MintInfo) -> Result<Self, Self::Error> {
+        Ok(Self {
             name: info.name,
             pubkey: info.pubkey.and_then(|p| p.parse().ok()),
             version: info.version.map(Into::into),
@@ -659,13 +659,13 @@ impl From<MintInfo> for cdk::nuts::MintInfo {
             contact: info
                 .contact
                 .map(|contacts| contacts.into_iter().map(Into::into).collect()),
-            nuts: nuts_cdk,
+            nuts: info.nuts.try_into()?,
             icon_url: info.icon_url,
             urls: info.urls,
             motd: info.motd,
             time: info.time,
             tos_url: info.tos_url,
-        }
+        })
     }
 }
 
@@ -1027,6 +1027,71 @@ mod tests {
         };
 
         let result: Result<cdk::nuts::ProtectedEndpoint, _> = invalid_endpoint.try_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_protected_endpoint_custom_payment_method_path() {
+        let endpoint = ProtectedEndpoint {
+            method: "POST".to_string(),
+            path: "/v1/mint/custom-method".to_string(),
+        };
+
+        let converted: cdk::nuts::ProtectedEndpoint = endpoint
+            .try_into()
+            .expect("custom payment method routes should be accepted");
+        assert_eq!(
+            converted.path,
+            cdk::nuts::RoutePath::Mint("custom-method".to_string())
+        );
+    }
+
+    #[test]
+    fn test_mint_info_unknown_endpoint_returns_error() {
+        let ffi_mint_info = MintInfo {
+            name: None,
+            pubkey: None,
+            version: None,
+            description: None,
+            description_long: None,
+            contact: None,
+            nuts: Nuts {
+                nut04: Nut04Settings {
+                    methods: vec![],
+                    disabled: false,
+                },
+                nut05: Nut05Settings {
+                    methods: vec![],
+                    disabled: false,
+                },
+                nut07_supported: true,
+                nut08_supported: false,
+                nut09_supported: false,
+                nut10_supported: false,
+                nut11_supported: false,
+                nut12_supported: true,
+                nut14_supported: false,
+                nut20_supported: false,
+                nut21: None,
+                nut22: Some(BlindAuthSettings {
+                    bat_max_mint: 10,
+                    protected_endpoints: vec![ProtectedEndpoint {
+                        method: "POST".to_string(),
+                        path: "/v1/unknown-custom-endpoint".to_string(),
+                    }],
+                }),
+                nut29: Nut29Settings::default(),
+                mint_units: vec![],
+                melt_units: vec![],
+            },
+            icon_url: None,
+            urls: None,
+            motd: None,
+            time: None,
+            tos_url: None,
+        };
+
+        let result = cdk::nuts::MintInfo::try_from(ffi_mint_info);
         assert!(result.is_err());
     }
 }

--- a/crates/cdk-ffi/src/wallet_repository.rs
+++ b/crates/cdk-ffi/src/wallet_repository.rs
@@ -37,29 +37,14 @@ impl WalletRepository {
         // Convert the FFI database trait to a CDK database implementation
         let localstore = crate::database::create_cdk_database_from_ffi(db);
 
-        let wallet = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move {
-                    WalletRepositoryBuilder::new()
-                        .localstore(localstore)
-                        .seed(seed)
-                        .build()
-                        .await
-                })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move {
-                        WalletRepositoryBuilder::new()
-                            .localstore(localstore)
-                            .seed(seed)
-                            .build()
-                            .await
-                    })
-            }
-        }?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let wallet = rt.block_on(async move {
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed(seed)
+                .build()
+                .await
+        })?;
 
         Ok(Self {
             inner: Arc::new(wallet),
@@ -87,31 +72,15 @@ impl WalletRepository {
         let proxy_url = url::Url::parse(&proxy_url)
             .map_err(|e| FfiError::internal(format!("Invalid URL: {}", e)))?;
 
-        let wallet = match tokio::runtime::Handle::try_current() {
-            Ok(handle) => tokio::task::block_in_place(|| {
-                handle.block_on(async move {
-                    WalletRepositoryBuilder::new()
-                        .localstore(localstore)
-                        .seed(seed)
-                        .proxy_url(proxy_url)
-                        .build()
-                        .await
-                })
-            }),
-            Err(_) => {
-                // No current runtime, create a new one
-                tokio::runtime::Runtime::new()
-                    .map_err(|e| FfiError::internal(format!("Failed to create runtime: {}", e)))?
-                    .block_on(async move {
-                        WalletRepositoryBuilder::new()
-                            .localstore(localstore)
-                            .seed(seed)
-                            .proxy_url(proxy_url)
-                            .build()
-                            .await
-                    })
-            }
-        }?;
+        let rt = crate::runtime::RuntimeGuard::new().map_err(FfiError::internal)?;
+        let wallet = rt.block_on(async move {
+            WalletRepositoryBuilder::new()
+                .localstore(localstore)
+                .seed(seed)
+                .proxy_url(proxy_url)
+                .build()
+                .await
+        })?;
 
         Ok(Self {
             inner: Arc::new(wallet),

--- a/crates/cdk-ffi/tests/test_kvstore.py
+++ b/crates/cdk-ffi/tests/test_kvstore.py
@@ -42,6 +42,12 @@ def create_test_db():
     return db, db_path
 
 
+def create_test_memory_db():
+    """Create an in-memory SQLite database for testing"""
+    backend = cdk_ffi.WalletDbBackend.SQLITE(path=":memory:")
+    return cdk_ffi.create_wallet_db(backend)
+
+
 def cleanup_db(db_path):
     """Clean up the temporary database file"""
     if os.path.exists(db_path):
@@ -374,6 +380,31 @@ async def test_kv_persistence_across_instances():
             os.unlink(db_path)
 
 
+async def test_kv_in_memory_concurrent_access():
+    """Test concurrent FFI access to the single-connection in-memory SQLite pool"""
+    print("\n=== Test: KV In-Memory Concurrent Access ===")
+
+    db = create_test_memory_db()
+
+    async def write_and_read(index):
+        key = f"key_{index}"
+        value = f"value_{index}".encode()
+        await db.kv_write("memory", "concurrent", key, value)
+        result = await db.kv_read("memory", "concurrent", key)
+        assert result is not None, f"Expected value for {key}"
+        assert bytes(result) == value, f"Expected {value}, got {bytes(result)}"
+
+    await asyncio.wait_for(
+        asyncio.gather(*(write_and_read(index) for index in range(64))),
+        timeout=10.0,
+    )
+
+    keys = await db.kv_list("memory", "concurrent")
+    assert len(keys) == 64, f"Expected 64 keys, got {len(keys)}"
+
+    print("  Test passed: concurrent in-memory KV access works")
+
+
 async def main():
     """Run all KV store tests"""
     print("Starting CDK FFI Key-Value Store Tests")
@@ -395,6 +426,8 @@ async def main():
         ("KV Special Key Names", test_kv_special_key_names),
         # Persistence
         ("KV Persistence Across Instances", test_kv_persistence_across_instances),
+        # In-memory SQLite pool
+        ("KV In-Memory Concurrent Access", test_kv_in_memory_concurrent_access),
     ]
 
     passed = 0

--- a/crates/cdk-integration-tests/tests/mint.rs
+++ b/crates/cdk-integration-tests/tests/mint.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use bip39::Mnemonic;
 use cashu::nut00::KnownMethod;
+use cashu::util::unix_time;
 use cashu::PaymentMethod;
 use cdk::mint::{MintBuilder, MintMeltLimits};
 use cdk::nuts::CurrencyUnit;
@@ -397,4 +398,103 @@ async fn test_rotate_keyset_with_expiry() {
     // Exactly one should be active
     let active_count = keysets.keysets.iter().filter(|k| k.active).count();
     assert_eq!(active_count, 1, "Exactly one keyset should be active");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_builder_does_not_replace_all_expired_keysets() {
+    use cdk_common::database::mint::KeysDatabase;
+
+    let mnemonic = Mnemonic::generate(12).unwrap();
+    let fee_reserve = FeeReserve {
+        min_fee_reserve: 1.into(),
+        percent_fee_reserve: 1.0,
+    };
+
+    let database = memory::empty().await.expect("valid db instance");
+    let localstore = Arc::new(database);
+
+    let fake_wallet1 = FakeWallet::new(
+        fee_reserve.clone(),
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+    let mut builder1 = MintBuilder::new(localstore.clone());
+    builder1 = builder1
+        .with_name("test mint".to_string())
+        .with_description("test mint".to_string());
+    builder1
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet1),
+        )
+        .await
+        .unwrap();
+    let mint = builder1
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+    mint.set_quote_ttl(QuoteTTL::new(10000, 10000))
+        .await
+        .unwrap();
+
+    assert_eq!(mint.keysets().keysets.len(), 1);
+
+    let future_expiry = unix_time() + 1_000_000;
+    let new_keyset = mint
+        .rotate_keyset(
+            CurrencyUnit::Sat,
+            cdk_integration_tests::standard_keyset_amounts(32),
+            0,
+            true,
+            Some(future_expiry),
+        )
+        .await
+        .unwrap();
+
+    let count_before_rebuild = mint.keysets().keysets.len();
+    assert_eq!(count_before_rebuild, 2);
+
+    // Mutate final_expiry to be in the past via localstore upsert.
+    drop(mint);
+    {
+        let mut info = KeysDatabase::get_keyset_info(&*localstore, &new_keyset.id)
+            .await
+            .unwrap()
+            .expect("rotated keyset should be present in localstore");
+        info.final_expiry = Some(unix_time().saturating_sub(1));
+        let mut tx = KeysDatabase::begin_transaction(&*localstore).await.unwrap();
+        tx.add_keyset_info(info).await.unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    let fake_wallet2 = FakeWallet::new(
+        fee_reserve,
+        HashMap::default(),
+        HashSet::default(),
+        0,
+        CurrencyUnit::Sat,
+    );
+    let mut builder2 = MintBuilder::new(localstore.clone());
+    builder2 = builder2
+        .with_name("test mint".to_string())
+        .with_description("test mint".to_string());
+    builder2
+        .add_payment_processor(
+            CurrencyUnit::Sat,
+            PaymentMethod::Known(KnownMethod::Bolt11),
+            MintMeltLimits::new(1, 5_000),
+            Arc::new(fake_wallet2),
+        )
+        .await
+        .unwrap();
+    let mint2 = builder2
+        .build_with_seed(localstore.clone(), &mnemonic.to_seed_normalized(""))
+        .await
+        .unwrap();
+
+    assert_eq!(mint2.keysets().keysets.len(), count_before_rebuild);
 }

--- a/crates/cdk-signatory/src/common.rs
+++ b/crates/cdk-signatory/src/common.rs
@@ -34,6 +34,14 @@ pub async fn init_keysets(
             keysets.sort_by_key(|b| std::cmp::Reverse(b.derivation_path_index));
 
             if let Some(highest_index_keyset) = keysets.first() {
+                if highest_index_keyset.is_expired() {
+                    tracing::info!(
+                        "Highest index keyset for unit {} has expired, skipping reactivation",
+                        unit
+                    );
+                    continue;
+                }
+
                 // Check if it matches our criteria
                 if highest_index_keyset.input_fee_ppk == *input_fee_ppk
                     && highest_index_keyset.amounts == *amounts

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -138,6 +138,9 @@ impl Signatory for DbSignatory {
                 if !info.active {
                     return Err(Error::InactiveKeyset);
                 }
+                if info.is_expired() {
+                    return Err(Error::ExpiredKeyset);
+                }
 
                 let key_pair = key.keys.get(&amount).ok_or(Error::UnknownKeySet)?;
                 let c = sign_message(&key_pair.secret_key, &blinded_secret)?;
@@ -250,10 +253,52 @@ mod test {
 
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
+    use cdk_common::nuts::SecretKey;
     use cdk_common::util::hex;
+    use cdk_common::util::unix_time;
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;
+
+    #[tokio::test]
+    async fn blind_sign_rejects_expired_keyset() {
+        let store = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory db"),
+        );
+        let signatory = DbSignatory::new(
+            store,
+            b"test-seed-for-unit-tests",
+            Default::default(),
+            Default::default(),
+        )
+        .await
+        .expect("DbSignatory::new");
+
+        let expired_keyset = signatory
+            .rotate_keyset(RotateKeyArguments {
+                unit: CurrencyUnit::Sat,
+                amounts: vec![1, 2, 4, 8],
+                input_fee_ppk: 0,
+                keyset_id_type: cdk_common::nut02::KeySetVersion::Version00,
+                final_expiry: Some(unix_time() - 1),
+            })
+            .await
+            .expect("rotate_keyset");
+
+        // Expiry check runs before crypto, so an unsigned blinded secret is fine here.
+        let blinded_secret = SecretKey::generate().public_key();
+        let msg = BlindedMessage::new(Amount::from(1), expired_keyset.id, blinded_secret);
+
+        let result = signatory.blind_sign(vec![msg]).await;
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
+    }
 
     #[test]
     fn mint_mod_generate_keyset_from_seed() {

--- a/crates/cdk-signatory/src/db_signatory.rs
+++ b/crates/cdk-signatory/src/db_signatory.rs
@@ -254,8 +254,7 @@ mod test {
     use bitcoin::key::Secp256k1;
     use bitcoin::Network;
     use cdk_common::nuts::SecretKey;
-    use cdk_common::util::hex;
-    use cdk_common::util::unix_time;
+    use cdk_common::util::{hex, unix_time};
     use cdk_common::{Amount, MintKeySet, PublicKey};
 
     use super::*;

--- a/crates/cdk-signatory/src/signatory.rs
+++ b/crates/cdk-signatory/src/signatory.rs
@@ -89,6 +89,14 @@ pub struct SignatoryKeySet {
     pub version: u32,
 }
 
+impl SignatoryKeySet {
+    /// Returns true if `final_expiry` is set and strictly in the past.
+    pub fn is_expired(&self) -> bool {
+        self.final_expiry
+            .is_some_and(|expiry| expiry < cdk_common::util::unix_time())
+    }
+}
+
 impl From<&SignatoryKeySet> for KeySet {
     fn from(val: &SignatoryKeySet) -> Self {
         val.to_owned().into()
@@ -171,4 +179,61 @@ pub trait Signatory {
     /// Add current keyset to inactive keysets
     /// Generate new keyset
     async fn rotate_keyset(&self, args: RotateKeyArguments) -> Result<SignatoryKeySet, Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    use cdk_common::nuts::nut01::Keys;
+    use cdk_common::util::unix_time;
+    use cdk_common::{CurrencyUnit, Id};
+
+    use super::*;
+
+    fn dummy_signatory_keyset(final_expiry: Option<u64>) -> SignatoryKeySet {
+        SignatoryKeySet {
+            id: Id::from_str("009a1f293253e41e").unwrap(),
+            unit: CurrencyUnit::Sat,
+            active: true,
+            keys: Keys::new(BTreeMap::new()),
+            amounts: vec![1, 2, 4, 8, 16, 32, 64, 128, 256, 512],
+            input_fee_ppk: 0,
+            final_expiry,
+            issuer_version: None,
+            version: 0,
+        }
+    }
+
+    #[test]
+    fn test_is_expired_none() {
+        let ks = dummy_signatory_keyset(None);
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_far_future() {
+        let ks = dummy_signatory_keyset(Some(unix_time() + 1_000_000));
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_exactly_now_is_not_expired() {
+        // strict less-than: expiry == now is not yet expired
+        let ks = dummy_signatory_keyset(Some(unix_time()));
+        assert!(!ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_one_second_ago() {
+        let ks = dummy_signatory_keyset(Some(unix_time() - 1));
+        assert!(ks.is_expired());
+    }
+
+    #[test]
+    fn test_is_expired_zero() {
+        let ks = dummy_signatory_keyset(Some(0));
+        assert!(ks.is_expired());
+    }
 }

--- a/crates/cdk-sql-common/src/keyvalue.rs
+++ b/crates/cdk-sql-common/src/keyvalue.rs
@@ -162,7 +162,7 @@ where
     // Validate parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, Some(key))?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     Ok(query(
         r#"
         SELECT value
@@ -195,7 +195,7 @@ where
     // Validate namespace parameters according to KV store requirements
     validate_kvstore_params(primary_namespace, secondary_namespace, None)?;
 
-    let conn = pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+    let conn = pool.get().await.map_err(|e| Error::Database(Box::new(e)))?;
     query(
         r#"
         SELECT key

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -340,9 +340,6 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
         let conn = self
             .pool
             .get()
@@ -368,10 +365,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/auth/mod.rs
+++ b/crates/cdk-sql-common/src/mint/auth/mod.rs
@@ -42,7 +42,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
         Ok(Self { pool })
     }
 
@@ -251,14 +251,21 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))
     }
 
     async fn get_active_keyset_id(&self) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -277,7 +284,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -301,7 +312,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -325,7 +340,14 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(vec![]);
+        }
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = query(r#"SELECT y, state FROM proof WHERE y IN (:ys)"#)?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
             .fetch_all(&*conn)
@@ -346,7 +368,15 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if blinded_messages.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -391,7 +421,11 @@ where
         &self,
         protected_endpoint: ProtectedEndpoint,
     ) -> Result<Option<AuthRequired>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT auth FROM protected_endpoints WHERE endpoint = :endpoint"#)?
                 .bind("endpoint", serde_json::to_string(&protected_endpoint)?)
@@ -411,7 +445,11 @@ where
     async fn get_auth_for_endpoints(
         &self,
     ) -> Result<HashMap<ProtectedEndpoint, Option<AuthRequired>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(r#"SELECT endpoint, auth FROM protected_endpoints"#)?
             .fetch_all(&*conn)
             .await?

--- a/crates/cdk-sql-common/src/mint/completed_operations.rs
+++ b/crates/cdk-sql-common/src/mint/completed_operations.rs
@@ -124,7 +124,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Option<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -152,7 +156,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -179,7 +187,11 @@ where
     }
 
     async fn get_completed_operations(&self) -> Result<Vec<mint::Operation>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/keys.rs
+++ b/crates/cdk-sql-common/src/mint/keys.rs
@@ -141,7 +141,10 @@ where
     ) -> Result<Box<dyn MintKeyDatabaseTransaction<'a, Error> + Send + Sync + 'a>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };
@@ -150,7 +153,11 @@ where
     }
 
     async fn get_active_keyset_id(&self, unit: &CurrencyUnit) -> Result<Option<Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#" SELECT id FROM keyset WHERE active = :active AND unit = :unit"#)?
                 .bind("active", true)
@@ -167,7 +174,11 @@ where
     }
 
     async fn get_active_keysets(&self) -> Result<HashMap<CurrencyUnit, Id>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(
             query(r#"SELECT id, unit FROM keyset WHERE active = :active"#)?
                 .bind("active", true)
@@ -185,7 +196,11 @@ where
     }
 
     async fn get_keyset_info(&self, id: &Id) -> Result<Option<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,
@@ -210,7 +225,11 @@ where
     }
 
     async fn get_keyset_infos(&self) -> Result<Vec<MintKeySetInfo>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"SELECT
                 id,

--- a/crates/cdk-sql-common/src/mint/keyvalue.rs
+++ b/crates/cdk-sql-common/src/mint/keyvalue.rs
@@ -105,7 +105,10 @@ where
     {
         Ok(Box::new(SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         }))

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/1_initial.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/1_initial.sql
@@ -95,6 +95,6 @@ CREATE TABLE mint_quote_issued (
   FOREIGN KEY (quote_id) REFERENCES mint_quote(id)
 );
 CREATE INDEX idx_mint_quote_issued_quote_id ON mint_quote_issued(quote_id);
-CREATE INDEX idx_melt_quote_request_lookup_id_and_kind ON mint_quote(
+CREATE INDEX idx_melt_quote_request_lookup_id_and_kind ON melt_quote(
   request_lookup_id, request_lookup_id_kind
 );

--- a/crates/cdk-sql-common/src/mint/migrations/postgres/20260427000000_fix_melt_quote_kind_index.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/postgres/20260427000000_fix_melt_quote_kind_index.sql
@@ -1,0 +1,5 @@
+-- Fix idx_melt_quote_request_lookup_id_and_kind if it was created on mint_quote.
+DROP INDEX IF EXISTS idx_melt_quote_request_lookup_id_and_kind;
+
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind
+ON melt_quote(request_lookup_id, request_lookup_id_kind);

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20250706101057_bolt12.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20250706101057_bolt12.sql
@@ -76,6 +76,6 @@ ALTER TABLE melt_quote ADD COLUMN payment_method TEXT NOT NULL DEFAULT 'bolt11';
 ALTER TABLE melt_quote ADD COLUMN options TEXT;
 ALTER TABLE melt_quote ADD COLUMN request_lookup_id_kind TEXT NOT NULL DEFAULT 'payment_hash';
 
-CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind ON mint_quote(request_lookup_id, request_lookup_id_kind);
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind ON melt_quote(request_lookup_id, request_lookup_id_kind);
 
 ALTER TABLE melt_quote DROP COLUMN msat_to_pay;

--- a/crates/cdk-sql-common/src/mint/migrations/sqlite/20260427000000_fix_melt_quote_kind_index.sql
+++ b/crates/cdk-sql-common/src/mint/migrations/sqlite/20260427000000_fix_melt_quote_kind_index.sql
@@ -1,0 +1,5 @@
+-- Fix idx_melt_quote_request_lookup_id_and_kind if it was created on mint_quote.
+DROP INDEX IF EXISTS idx_melt_quote_request_lookup_id_and_kind;
+
+CREATE INDEX IF NOT EXISTS idx_melt_quote_request_lookup_id_and_kind
+ON melt_quote(request_lookup_id, request_lookup_id_kind);

--- a/crates/cdk-sql-common/src/mint/mod.rs
+++ b/crates/cdk-sql-common/src/mint/mod.rs
@@ -66,7 +66,7 @@ where
     {
         let pool = Pool::new(db.into());
 
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -125,7 +125,10 @@ where
     ) -> Result<Box<dyn database::MintTransaction<Error> + Send + Sync>, Error> {
         let tx = SQLTransaction {
             inner: ConnectionWithTransaction::new(
-                self.pool.get().map_err(|e| Error::Database(Box::new(e)))?,
+                self.pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::Database(Box::new(e)))?,
             )
             .await?,
         };

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -407,10 +407,6 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        if ys.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/proofs.rs
+++ b/crates/cdk-sql-common/src/mint/proofs.rs
@@ -407,7 +407,15 @@ where
     type Err = Error;
 
     async fn get_proofs_by_ys(&self, ys: &[PublicKey]) -> Result<Vec<Option<Proof>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut proofs = query(
             r#"
             SELECT
@@ -446,7 +454,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -471,7 +483,11 @@ where
     }
 
     async fn get_proofs_states(&self, ys: &[PublicKey]) -> Result<Vec<Option<State>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut current_states = get_current_states(&*conn, ys, false).await?;
 
         Ok(ys.iter().map(|y| current_states.remove(y)).collect())
@@ -481,7 +497,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<(Proofs, Vec<Option<State>>), Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (proofs, states): (Vec<Proof>, Vec<State>) = query(
             r#"
@@ -512,7 +532,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_redeemed(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -533,7 +557,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/quotes.rs
+++ b/crates/cdk-sql-common/src/mint/quotes.rs
@@ -1117,7 +1117,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_mint_quote_inner(&*conn, quote_id, false).await;
 
@@ -1141,7 +1145,11 @@ where
         &self,
         quote_ids: &[QuoteId],
     ) -> Result<Vec<Option<MintQuote>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quotes_inner(&*conn, quote_ids, false).await
     }
 
@@ -1149,7 +1157,11 @@ where
         &self,
         request: &str,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_inner(&*conn, request, false).await
     }
 
@@ -1157,12 +1169,20 @@ where
         &self,
         request_lookup_id: &PaymentIdentifier,
     ) -> Result<Option<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         get_mint_quote_by_request_lookup_id_inner(&*conn, request_lookup_id, false).await
     }
 
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut mint_quotes = query(
             r#"
             SELECT
@@ -1208,7 +1228,11 @@ where
 
         #[cfg(feature = "prometheus")]
         let start_time = std::time::Instant::now();
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let result = get_melt_quote_inner(&*conn, quote_id, false).await;
 
@@ -1229,7 +1253,11 @@ where
     }
 
     async fn get_melt_quotes(&self) -> Result<Vec<mint::MeltQuote>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/saga.rs
+++ b/crates/cdk-sql-common/src/mint/saga.rs
@@ -222,7 +222,11 @@ where
         &self,
         quote_id: &cdk_common::QuoteId,
     ) -> Result<Option<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/saga.rs
+++ b/crates/cdk-sql-common/src/mint/saga.rs
@@ -252,7 +252,11 @@ where
         &self,
         operation_kind: mint::OperationKind,
     ) -> Result<Vec<mint::Saga>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -261,10 +261,6 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        if blinded_messages.is_empty() {
-            return Ok(vec![]);
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/mint/signatures.rs
+++ b/crates/cdk-sql-common/src/mint/signatures.rs
@@ -261,7 +261,15 @@ where
         &self,
         blinded_messages: &[PublicKey],
     ) -> Result<Vec<Option<BlindSignature>>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if blinded_messages.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let mut blinded_signatures = query(
             r#"SELECT
                 keyset_id,
@@ -306,7 +314,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -334,7 +346,11 @@ where
         &self,
         quote_id: &QuoteId,
     ) -> Result<Vec<BlindSignature>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -359,7 +375,11 @@ where
 
     /// Get total proofs redeemed by keyset id
     async fn get_total_issued(&self) -> Result<HashMap<Id, Amount>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -380,7 +400,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<PublicKey>, Self::Err> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -4,12 +4,13 @@
 
 use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 #[cfg(feature = "prometheus")]
 use cdk_prometheus::metrics::METRICS;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::database::DatabaseConnector;
 
@@ -67,17 +68,29 @@ pub trait DatabasePool: Debug {
 }
 
 /// Generic connection pool of resources R
-#[derive(Debug)]
 pub struct Pool<RM>
 where
     RM: DatabasePool,
 {
     config: RM::Config,
     queue: Mutex<Vec<(Arc<AtomicBool>, RM::Connection)>>,
-    in_use: AtomicUsize,
     max_size: usize,
     default_timeout: Duration,
-    waiter: Condvar,
+    semaphore: Arc<Semaphore>,
+}
+
+impl<RM> Debug for Pool<RM>
+where
+    RM: DatabasePool,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Pool")
+            .field("config", &self.config)
+            .field("max_size", &self.max_size)
+            .field("default_timeout", &self.default_timeout)
+            .field("available_permits", &self.semaphore.available_permits())
+            .finish()
+    }
 }
 
 /// The pooled resource
@@ -87,8 +100,9 @@ where
 {
     resource: Option<(Arc<AtomicBool>, RM::Connection)>,
     pool: Arc<Pool<RM>>,
+    _permit: OwnedSemaphorePermit,
     #[cfg(feature = "prometheus")]
-    start_time: Instant,
+    start_time: std::time::Instant,
 }
 
 impl<RM> Debug for PooledResource<RM>
@@ -108,19 +122,19 @@ where
         if let Some(resource) = self.resource.take() {
             let mut active_resource = self.pool.queue.lock().expect("active_resource");
             active_resource.push(resource);
-            let _in_use = self.pool.in_use.fetch_sub(1, Ordering::AcqRel);
 
             #[cfg(feature = "prometheus")]
             {
-                METRICS.set_db_connections_active(_in_use as i64);
+                let in_use = self.pool.max_size - self.pool.semaphore.available_permits();
+                METRICS.set_db_connections_active(in_use as i64);
 
                 let duration = self.start_time.elapsed().as_secs_f64();
 
                 METRICS.record_db_operation(duration, "drop");
             }
 
-            // Notify a waiting thread
-            self.pool.waiter.notify_one();
+            // The semaphore permit is dropped automatically after this,
+            // which wakes any async task waiting in `get()`.
         }
     }
 }
@@ -151,103 +165,88 @@ where
 {
     /// Creates a new pool
     pub fn new(config: RM::Config) -> Arc<Self> {
+        let max_size = config.max_size();
         Arc::new(Self {
             default_timeout: config.default_timeout(),
-            max_size: config.max_size(),
+            max_size,
             config,
             queue: Default::default(),
-            in_use: Default::default(),
-            waiter: Default::default(),
+            semaphore: Arc::new(Semaphore::new(max_size)),
         })
     }
 
     /// Similar to get_timeout but uses the default timeout value.
     #[inline(always)]
-    pub fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        self.get_timeout(self.default_timeout)
-    }
-
-    /// Increments the in_use connection counter and updates the metric
-    fn increment_connection_counter(&self) -> usize {
-        let in_use = self.in_use.fetch_add(1, Ordering::AcqRel);
-
-        #[cfg(feature = "prometheus")]
-        {
-            METRICS.set_db_connections_active(in_use as i64);
-        }
-
-        in_use
+    pub async fn get(self: &Arc<Self>) -> Result<PooledResource<RM>, Error<RM::Error>> {
+        self.get_timeout(self.default_timeout).await
     }
 
     /// Get a new resource or fail after timeout is reached.
     ///
     /// This function will return a free resource or create a new one if there is still room for it;
-    /// otherwise, it will wait for a resource to be released for reuse.
+    /// otherwise, it will asynchronously wait for a resource to be released for reuse.
     #[inline(always)]
-    pub fn get_timeout(
+    pub async fn get_timeout(
         self: &Arc<Self>,
         timeout: Duration,
     ) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
-        let time = Instant::now();
+        // Acquire a semaphore permit asynchronously. This yields the task instead of
+        // blocking the OS thread, preventing Tokio worker thread starvation.
+        let permit =
+            match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_closed)) => {
+                    // Semaphore was closed (pool is being dropped)
+                    return Err(Error::Poison);
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        "Timeout waiting for the resource (pool size: {})",
+                        self.max_size,
+                    );
+                    return Err(Error::Timeout);
+                }
+            };
 
-        loop {
+        #[cfg(feature = "prometheus")]
+        {
+            let in_use = self.max_size - self.semaphore.available_permits();
+            METRICS.set_db_connections_active(in_use as i64);
+        }
+
+        // Briefly lock the idle queue to try to pop a non-stale connection.
+        // This mutex is held for nanoseconds (just a Vec::pop).
+        {
+            let mut resources = self.queue.lock().map_err(|_| Error::Poison)?;
             while let Some((stale, resource)) = resources.pop() {
                 if !stale.load(Ordering::SeqCst) {
-                    // Increment counter BEFORE releasing the mutex to prevent race condition
-                    // where another thread sees in_use < max_size and creates a duplicate connection.
-                    // For in-memory SQLite, each connection is a separate database, so this race
-                    // would cause some connections to miss migrations.
-                    self.increment_connection_counter();
-
                     return Ok(PooledResource {
                         resource: Some((stale, resource)),
                         pool: self.clone(),
+                        _permit: permit,
                         #[cfg(feature = "prometheus")]
-                        start_time: Instant::now(),
+                        start_time: std::time::Instant::now(),
                     });
                 }
+                // Stale connection — drop it and keep looking.
             }
+        }
 
-            if self.in_use.load(Ordering::Relaxed) < self.max_size {
-                // Increment counter BEFORE releasing the mutex to prevent race condition.
-                // This ensures other threads see the updated count and wait instead of
-                // creating additional connections beyond max_size.
-                self.increment_connection_counter();
-                let stale: Arc<AtomicBool> = Arc::new(false.into());
-                match RM::new_resource(&self.config, stale.clone(), timeout) {
-                    Ok(new_resource) => {
-                        return Ok(PooledResource {
-                            resource: Some((stale, new_resource)),
-                            pool: self.clone(),
-                            #[cfg(feature = "prometheus")]
-                            start_time: Instant::now(),
-                        });
-                    }
-                    Err(e) => {
-                        // If resource creation fails, decrement the counter we just incremented
-                        self.in_use.fetch_sub(1, Ordering::AcqRel);
-                        return Err(e);
-                    }
-                }
+        // No idle connection available — create a new one.
+        // The semaphore already guarantees we won't exceed max_size.
+        let stale: Arc<AtomicBool> = Arc::new(false.into());
+        match RM::new_resource(&self.config, stale.clone(), timeout) {
+            Ok(new_resource) => Ok(PooledResource {
+                resource: Some((stale, new_resource)),
+                pool: self.clone(),
+                _permit: permit,
+                #[cfg(feature = "prometheus")]
+                start_time: std::time::Instant::now(),
+            }),
+            Err(e) => {
+                // Permit is dropped here, releasing the slot back to the semaphore.
+                Err(e)
             }
-
-            resources = self
-                .waiter
-                .wait_timeout(resources, timeout)
-                .map_err(|_| Error::Poison)
-                .and_then(|(lock, timeout_result)| {
-                    if timeout_result.timed_out() {
-                        tracing::warn!(
-                            "Timeout waiting for the resource (pool size: {}). Waited {} ms",
-                            self.max_size,
-                            time.elapsed().as_millis()
-                        );
-                        Err(Error::Timeout)
-                    } else {
-                        Ok(lock)
-                    }
-                })?;
         }
     }
 }
@@ -257,21 +256,13 @@ where
     RM: DatabasePool,
 {
     fn drop(&mut self) {
+        // Close the semaphore so no new acquisitions can succeed.
+        self.semaphore.close();
+
+        // Drain all idle connections.
         if let Ok(mut resources) = self.queue.lock() {
-            loop {
-                while let Some(resource) = resources.pop() {
-                    RM::drop(resource.1);
-                }
-
-                if self.in_use.load(Ordering::Relaxed) == 0 {
-                    break;
-                }
-
-                resources = if let Ok(resources) = self.waiter.wait(resources) {
-                    resources
-                } else {
-                    break;
-                };
+            while let Some(resource) = resources.pop() {
+                RM::drop(resource.1);
             }
         }
     }

--- a/crates/cdk-sql-common/src/pool.rs
+++ b/crates/cdk-sql-common/src/pool.rs
@@ -190,23 +190,24 @@ where
         self: &Arc<Self>,
         timeout: Duration,
     ) -> Result<PooledResource<RM>, Error<RM::Error>> {
-        // Acquire a semaphore permit asynchronously. This yields the task instead of
-        // blocking the OS thread, preventing Tokio worker thread starvation.
-        let permit =
-            match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
-                Ok(Ok(permit)) => permit,
-                Ok(Err(_closed)) => {
-                    // Semaphore was closed (pool is being dropped)
-                    return Err(Error::Poison);
-                }
-                Err(_elapsed) => {
-                    tracing::warn!(
-                        "Timeout waiting for the resource (pool size: {})",
-                        self.max_size,
-                    );
-                    return Err(Error::Timeout);
-                }
-            };
+        // Fast path: try to grab a permit without waiting.
+        let permit = match self.semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(tokio::sync::TryAcquireError::Closed) => return Err(Error::Poison),
+            Err(tokio::sync::TryAcquireError::NoPermits) => {
+                // All permits are in use — wait asynchronously.  This yields
+                // the task instead of blocking the OS thread, preventing Tokio
+                // worker thread starvation.
+                tracing::debug!(
+                    "Pool exhausted (size: {}), waiting for a connection",
+                    self.max_size,
+                );
+                tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned())
+                    .await
+                    .map_err(|_| Error::Timeout)?
+                    .map_err(|_| Error::Poison)?
+            }
+        };
 
         #[cfg(feature = "prometheus")]
         {

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -550,10 +550,6 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        if ys.is_empty() {
-            return Ok(Vec::new());
-        }
-
         let conn = self
             .pool
             .get()
@@ -853,10 +849,6 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        if ys.is_empty() {
-            return Ok(());
-        }
-
         let conn = self
             .pool
             .get()

--- a/crates/cdk-sql-common/src/wallet/mod.rs
+++ b/crates/cdk-sql-common/src/wallet/mod.rs
@@ -55,7 +55,7 @@ where
         X: Into<RM::Config>,
     {
         let pool = Pool::new(db.into());
-        Self::migrate(pool.get().map_err(|e| Error::Database(Box::new(e)))?).await?;
+        Self::migrate(pool.get().await.map_err(|e| Error::Database(Box::new(e)))?).await?;
 
         Ok(Self { pool })
     }
@@ -150,7 +150,11 @@ where
 {
     #[instrument(skip(self))]
     async fn get_melt_quotes(&self) -> Result<Vec<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -180,7 +184,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint(&self, mint_url: MintUrl) -> Result<Option<MintInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -210,7 +218,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mints(&self) -> Result<HashMap<MintUrl, Option<MintInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
                 SELECT
@@ -250,7 +262,11 @@ where
         &self,
         mint_url: MintUrl,
     ) -> Result<Option<Vec<KeySetInfo>>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let keysets = query(
             r#"
@@ -283,7 +299,11 @@ where
         &self,
         keyset_id: &Id,
     ) -> Result<Option<KeySetInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -306,7 +326,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quote(&self, quote_id: &str) -> Result<Option<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -338,7 +362,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -368,7 +396,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_unissued_mint_quotes(&self) -> Result<Vec<MintQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -405,7 +437,11 @@ where
         &self,
         quote_id: &str,
     ) -> Result<Option<wallet::MeltQuote>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -436,7 +472,11 @@ where
 
     #[instrument(skip(self), fields(keyset_id = %keyset_id))]
     async fn get_keys(&self, keyset_id: &Id) -> Result<Option<Keys>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         query(
             r#"
             SELECT
@@ -463,7 +503,11 @@ where
         state: Option<Vec<State>>,
         spending_conditions: Option<Vec<SpendingConditions>>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -506,7 +550,15 @@ where
         &self,
         ys: Vec<PublicKey>,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -544,7 +596,11 @@ where
         unit: Option<CurrencyUnit>,
         states: Option<Vec<State>>,
     ) -> Result<u64, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mut query_str = "SELECT COALESCE(SUM(amount), 0) as total FROM proof".to_string();
         let mut where_clauses = Vec::new();
@@ -607,7 +663,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<Option<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         Ok(query(
             r#"
             SELECT
@@ -645,7 +705,11 @@ where
         direction: Option<TransactionDirection>,
         unit: Option<CurrencyUnit>,
     ) -> Result<Vec<Transaction>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         Ok(query(
             r#"
@@ -688,7 +752,11 @@ where
         added: Vec<ProofInfo>,
         removed_ys: Vec<PublicKey>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for proof in added {
@@ -785,7 +853,15 @@ where
         ys: Vec<PublicKey>,
         state: State,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        if ys.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query("UPDATE proof SET state = :state WHERE y IN (:ys)")?
             .bind_vec("ys", ys.iter().map(|y| y.to_bytes().to_vec()).collect())?
@@ -798,7 +874,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_transaction(&self, transaction: Transaction) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let mint_url = transaction.mint_url.to_string();
         let direction = transaction.direction.to_string();
@@ -866,7 +946,11 @@ where
         old_mint_url: MintUrl,
         new_mint_url: MintUrl,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
         let tables = ["mint_quote", "proof"];
 
@@ -895,7 +979,11 @@ where
         keyset_id: &Id,
         count: u32,
     ) -> Result<u32, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let new_counter = query(
             r#"
@@ -923,7 +1011,11 @@ where
         mint_url: MintUrl,
         mint_info: Option<MintInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let (
             name,
@@ -1024,7 +1116,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint(&self, mint_url: MintUrl) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint WHERE mint_url=:mint_url"#)?
             .bind("mint_url", mint_url.to_string())
@@ -1040,7 +1136,11 @@ where
         mint_url: MintUrl,
         keysets: Vec<KeySetInfo>,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let tx = ConnectionWithTransaction::new(conn).await?;
 
         for keyset in keysets {
@@ -1073,7 +1173,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_mint_quote(&self, quote: MintQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1127,7 +1231,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_mint_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM mint_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_string())
@@ -1139,7 +1247,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_melt_quote(&self, quote: wallet::MeltQuote) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let expected_version = quote.version;
         let new_version = expected_version.wrapping_add(1);
@@ -1190,7 +1302,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_melt_quote(&self, quote_id: &str) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM melt_quote WHERE id=:id"#)?
             .bind("id", quote_id.to_owned())
@@ -1202,7 +1318,11 @@ where
 
     #[instrument(skip_all)]
     async fn add_keys(&self, keyset: KeySet) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         keyset.verify_id()?;
 
@@ -1228,7 +1348,11 @@ where
 
     #[instrument(skip(self))]
     async fn remove_keys(&self, id: &Id) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM key WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1243,7 +1367,11 @@ where
         &self,
         transaction_id: TransactionId,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM transactions WHERE id=:id"#)?
             .bind("id", transaction_id.as_slice().to_vec())
@@ -1255,7 +1383,11 @@ where
 
     #[instrument(skip(self))]
     async fn add_saga(&self, saga: wallet::WalletSaga) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1301,7 +1433,11 @@ where
         &self,
         id: &uuid::Uuid,
     ) -> Result<Option<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1322,7 +1458,11 @@ where
 
     #[instrument(skip(self))]
     async fn update_saga(&self, saga: wallet::WalletSaga) -> Result<bool, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let state_json = serde_json::to_string(&saga.state).map_err(|e| {
             Error::Database(Box::new(std::io::Error::new(
@@ -1372,7 +1512,11 @@ where
 
     #[instrument(skip(self))]
     async fn delete_saga(&self, id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(r#"DELETE FROM wallet_sagas WHERE id = :id"#)?
             .bind("id", id.to_string())
@@ -1384,7 +1528,11 @@ where
 
     #[instrument(skip(self))]
     async fn get_incomplete_sagas(&self) -> Result<Vec<wallet::WalletSaga>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1405,7 +1553,11 @@ where
         ys: Vec<PublicKey>,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         for y in ys {
             let rows_affected = query(
@@ -1430,7 +1582,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_proofs(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1451,7 +1607,11 @@ where
         &self,
         operation_id: &uuid::Uuid,
     ) -> Result<Vec<ProofInfo>, database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows = query(
             r#"
@@ -1489,7 +1649,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1525,7 +1689,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_melt_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1547,7 +1715,11 @@ where
         quote_id: &str,
         operation_id: &uuid::Uuid,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         let rows_affected = query(
             r#"
@@ -1583,7 +1755,11 @@ where
 
     #[instrument(skip(self))]
     async fn release_mint_quote(&self, operation_id: &uuid::Uuid) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
 
         query(
             r#"
@@ -1623,7 +1799,11 @@ where
         key: &str,
         value: &[u8],
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_write_standalone(
             &*conn,
             primary_namespace,
@@ -1641,7 +1821,11 @@ where
         secondary_namespace: &str,
         key: &str,
     ) -> Result<(), database::Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         crate::keyvalue::kv_remove_standalone(&*conn, primary_namespace, secondary_namespace, key)
             .await?;
         Ok(())
@@ -1656,7 +1840,11 @@ where
         derivation_path: DerivationPath,
         derivation_index: u32,
     ) -> Result<(), Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         INSERT INTO p2pk_signing_key (pubkey, derivation_index, derivation_path, created_time)
         VALUES (:pubkey, :derivation_index, :derivation_path, :created_time)
@@ -1679,7 +1867,11 @@ where
         &self,
         pubkey: &PublicKey,
     ) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key WHERE pubkey = :pubkey"#.to_string();
 
         query(&query_str)?
@@ -1692,7 +1884,11 @@ where
 
     #[instrument(skip(self))]
     async fn list_p2pk_keys(&self) -> Result<Vec<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC
         "#.to_string();
@@ -1711,7 +1907,11 @@ where
 
     #[instrument(skip(self))]
     async fn latest_p2pk(&self) -> Result<Option<wallet::P2PKSigningKey>, Error> {
-        let conn = self.pool.get().map_err(|e| Error::Database(Box::new(e)))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| Error::Database(Box::new(e)))?;
         let query_str = r#"
         SELECT pubkey, derivation_index, derivation_path, created_time FROM p2pk_signing_key ORDER BY derivation_index DESC LIMIT 1
         "#.to_string();

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -35,7 +35,7 @@ mod test {
         let config: Config = "test.db".into();
 
         let pool = Pool::<SqliteConnectionManager>::new(config);
-        let db = pool.get();
+        let db = pool.get().await;
         assert!(db.is_ok());
         let _ = remove_file("test.db");
     }
@@ -56,7 +56,7 @@ mod test {
 
             let pool = Pool::<SqliteConnectionManager>::new(config);
 
-            let conn = pool.get().expect("valid connection");
+            let conn = pool.get().await.expect("valid connection");
 
             query(include_str!("../../tests/legacy-sqlx.sql"))
                 .expect("query")

--- a/crates/cdk-sqlite/src/mint/mod.rs
+++ b/crates/cdk-sqlite/src/mint/mod.rs
@@ -16,6 +16,7 @@ pub type MintSqliteAuthDatabase = SQLMintAuthDatabase<SqliteConnectionManager>;
 #[cfg(test)]
 mod test {
     use std::fs::remove_file;
+    use std::time::Duration;
 
     use cdk_common::mint_db_test;
     use cdk_sql_common::pool::Pool;
@@ -38,6 +39,17 @@ mod test {
         let db = pool.get().await;
         assert!(db.is_ok());
         let _ = remove_file("test.db");
+    }
+
+    #[tokio::test]
+    async fn exhausted_in_memory_pool_times_out() {
+        let config: Config = ":memory:".into();
+        let pool = Pool::<SqliteConnectionManager>::new(config);
+
+        let _conn = pool.get().await.expect("valid connection");
+        let result = pool.get_timeout(Duration::from_millis(10)).await;
+
+        assert!(matches!(result, Err(cdk_sql_common::pool::Error::Timeout)));
     }
 
     #[tokio::test]

--- a/crates/cdk/src/mint/auth/mod.rs
+++ b/crates/cdk/src/mint/auth/mod.rs
@@ -2,8 +2,8 @@ use tracing::instrument;
 
 use super::nut21::ProtectedEndpoint;
 use super::{
-    AuthProof, AuthRequired, AuthToken, BlindAuthToken, BlindSignature, BlindedMessage, Error,
-    Mint, State,
+    AuthProof, AuthRequired, AuthToken, BlindAuthToken, BlindSignature, BlindedMessage,
+    CurrencyUnit, Error, Mint, State,
 };
 
 impl Mint {
@@ -34,6 +34,16 @@ impl Mint {
     /// Verify Blind auth
     #[instrument(skip(self, token))]
     pub async fn verify_blind_auth(&self, token: &BlindAuthToken) -> Result<(), Error> {
+        let keysets = self.keysets.load();
+        let keyset = keysets
+            .iter()
+            .find(|k| k.id == token.auth_proof.keyset_id)
+            .ok_or(Error::UnknownKeySet)?;
+
+        if keyset.unit != CurrencyUnit::Auth {
+            return Err(Error::BlindAuthFailed);
+        }
+
         self.signatory
             .verify_proofs(vec![token.auth_proof.clone().into()])
             .await

--- a/crates/cdk/src/mint/auth/mod.rs
+++ b/crates/cdk/src/mint/auth/mod.rs
@@ -14,7 +14,17 @@ impl Mint {
         method: &ProtectedEndpoint,
     ) -> Result<Option<AuthRequired>, Error> {
         if let Some(auth_db) = self.auth_localstore.as_ref() {
-            Ok(auth_db.get_auth_for_endpoint(method.clone()).await?)
+            if let Some(auth_required) = auth_db.get_auth_for_endpoint(method.clone()).await? {
+                return Ok(Some(auth_required));
+            }
+
+            Ok(auth_db
+                .get_auth_for_endpoints()
+                .await?
+                .into_iter()
+                .filter_map(|(endpoint, auth)| endpoint.match_specificity(method).zip(auth))
+                .max_by_key(|(specificity, _)| *specificity)
+                .map(|(_, auth)| auth))
         } else {
             Ok(None)
         }

--- a/crates/cdk/src/mint/auth/mod.rs
+++ b/crates/cdk/src/mint/auth/mod.rs
@@ -54,6 +54,10 @@ impl Mint {
             return Err(Error::BlindAuthFailed);
         }
 
+        if keyset.is_expired() {
+            return Err(Error::ExpiredKeyset);
+        }
+
         self.signatory
             .verify_proofs(vec![token.auth_proof.clone().into()])
             .await

--- a/crates/cdk/src/mint/builder.rs
+++ b/crates/cdk/src/mint/builder.rs
@@ -540,6 +540,10 @@ impl MintBuilder {
             let mut rotate = false;
 
             if let Some(keyset) = keyset {
+                if keyset.is_expired() {
+                    tracing::warn!("Active keyset for unit {} has expired; not rotating", unit);
+                    continue;
+                }
                 // Check if fee matches
                 if keyset.input_fee_ppk != *fee {
                     tracing::info!(

--- a/crates/cdk/src/mint/mod.rs
+++ b/crates/cdk/src/mint/mod.rs
@@ -1198,6 +1198,15 @@ impl Mint {
                 request.outputs.into_iter().zip(blinded_signatures)
             {
                 if let Some(blinded_signature) = blinded_signature {
+                    if let Some(keyset_info) = self.get_keyset_info(&blinded_signature.keyset_id) {
+                        if keyset_info.is_expired() {
+                            tracing::debug!(
+                                "Skipping restore for expired keyset {}",
+                                blinded_signature.keyset_id
+                            );
+                            continue;
+                        }
+                    }
                     outputs.push(blinded_message);
                     signatures.push(blinded_signature);
                 }
@@ -1779,5 +1788,85 @@ mod tests {
             rotation_result,
             Err(Error::UnitStringCollision(_currency_unit))
         ));
+    }
+
+    #[tokio::test]
+    async fn verify_outputs_keyset_rejects_expired_keyset() {
+        use cdk_common::nuts::SecretKey;
+        use cdk_common::util::unix_time;
+
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..8).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts));
+
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+
+        let current_keysets: Vec<SignatoryKeySet> = mint.keysets.load().as_ref().clone();
+        let keyset_id = current_keysets[0].id;
+
+        let expired_keysets: Vec<SignatoryKeySet> = current_keysets
+            .into_iter()
+            .map(|mut ks| {
+                ks.final_expiry = Some(unix_time() - 1);
+                ks
+            })
+            .collect();
+        mint.keysets.store(Arc::new(expired_keysets));
+
+        let blinded_secret = SecretKey::generate().public_key();
+        let output = BlindedMessage::new(Amount::from(1), keyset_id, blinded_secret);
+
+        let result = mint.verify_outputs_keyset(&[output]);
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_inputs_keyset_rejects_expired_keyset() {
+        use cdk_common::nuts::{Proof, SecretKey};
+        use cdk_common::secret::Secret;
+        use cdk_common::util::unix_time;
+
+        let mut supported_units = HashMap::new();
+        let amounts: Vec<u64> = (0..8).map(|i| 2u64.pow(i)).collect();
+        supported_units.insert(CurrencyUnit::default(), (0, amounts));
+
+        let config = MintConfig::<'_> {
+            supported_units,
+            ..Default::default()
+        };
+        let mint = create_mint(config).await;
+
+        let current_keysets: Vec<SignatoryKeySet> = mint.keysets.load().as_ref().clone();
+        let keyset_id = current_keysets[0].id;
+
+        let expired_keysets: Vec<SignatoryKeySet> = current_keysets
+            .into_iter()
+            .map(|mut ks| {
+                ks.final_expiry = Some(unix_time() - 1);
+                ks
+            })
+            .collect();
+        mint.keysets.store(Arc::new(expired_keysets));
+
+        // Expiry check runs before crypto, so an unsigned proof is fine here.
+        let c = SecretKey::generate().public_key();
+        let proof = Proof::new(Amount::from(1), keyset_id, Secret::generate(), c);
+
+        let result = mint.verify_inputs_keyset(&vec![proof]).await;
+
+        assert!(
+            matches!(result, Err(Error::ExpiredKeyset)),
+            "expected ExpiredKeyset error, got: {:?}",
+            result
+        );
     }
 }

--- a/crates/cdk/src/mint/subscription.rs
+++ b/crates/cdk/src/mint/subscription.rs
@@ -29,26 +29,36 @@ pub struct MintPubSubSpec {
 }
 
 impl MintPubSubSpec {
-    /// Call Mint::check_mint_quote_payments to update the quote pinging the payment backend
-    async fn get_mint_quote(
+    /// Call Mint::check_mint_quote_payments to update quotes by pinging the payment backend
+    async fn get_mint_quotes(
         &self,
-        quote_id: &QuoteId,
-    ) -> Result<Option<MintQuote>, cdk_common::Error> {
-        let mut quote = if let Some(quote) = self.db.get_mint_quote(quote_id).await? {
-            quote
-        } else {
-            return Ok(None);
-        };
+        quote_ids: &[QuoteId],
+    ) -> Result<HashMap<QuoteId, MintQuote>, cdk_common::Error> {
+        if quote_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
 
-        Mint::check_mint_quote_payments(
-            self.db.clone(),
-            self.payment_processors.clone(),
-            None,
-            &mut quote,
-        )
-        .await?;
+        let mut quotes = HashMap::new();
 
-        Ok(Some(quote))
+        for mut quote in self
+            .db
+            .get_mint_quotes_by_ids(quote_ids)
+            .await?
+            .into_iter()
+            .flatten()
+        {
+            Mint::check_mint_quote_payments(
+                self.db.clone(),
+                self.payment_processors.clone(),
+                None,
+                &mut quote,
+            )
+            .await?;
+
+            quotes.insert(quote.id.clone(), quote);
+        }
+
+        Ok(quotes)
     }
 
     async fn get_events_from_db(
@@ -57,6 +67,19 @@ impl MintPubSubSpec {
     ) -> Result<Vec<MintEvent<QuoteId>>, String> {
         let mut to_return = vec![];
         let mut public_keys: Vec<PublicKey> = Vec::new();
+        let mint_quote_ids = request
+            .iter()
+            .filter_map(|idx| match idx {
+                NotificationId::MintQuoteBolt11(uuid) | NotificationId::MintQuoteBolt12(uuid) => {
+                    Some(uuid.clone())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        let mint_quotes = self
+            .get_mint_quotes(&mint_quote_ids)
+            .await
+            .map_err(|e| e.to_string())?;
 
         for idx in request.iter() {
             match idx {
@@ -86,9 +109,7 @@ impl MintPubSubSpec {
                     }
                 }
                 NotificationId::MintQuoteBolt11(uuid) | NotificationId::MintQuoteBolt12(uuid) => {
-                    if let Some(mint_quote) =
-                        self.get_mint_quote(uuid).await.map_err(|e| e.to_string())?
-                    {
+                    if let Some(mint_quote) = mint_quotes.get(uuid).cloned() {
                         let mint_quote = match idx {
                             NotificationId::MintQuoteBolt11(_) => {
                                 let response: MintQuoteBolt11Response<QuoteId> = mint_quote.into();
@@ -303,5 +324,83 @@ impl Deref for PubSubManager {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cdk_common::database::DynMintDatabase;
+    use cdk_common::mint::MintQuote;
+    use cdk_common::payment::PaymentIdentifier;
+    use cdk_common::QuoteId;
+
+    use super::*;
+
+    fn paid_bolt11_quote(id: QuoteId, amount: u64) -> MintQuote {
+        MintQuote::new(
+            Some(id),
+            format!("lnbc1test{amount}"),
+            CurrencyUnit::Sat,
+            Some(Amount::new(amount, CurrencyUnit::Sat)),
+            0,
+            PaymentIdentifier::CustomId(format!("lookup-{amount}")),
+            None,
+            Amount::new(0, CurrencyUnit::Sat),
+            Amount::new(0, CurrencyUnit::Sat),
+            cdk_common::PaymentMethod::Known(cdk_common::nut00::KnownMethod::Bolt11),
+            0,
+            vec![],
+            vec![],
+            None,
+        )
+    }
+
+    async fn add_mint_quote(db: &DynMintDatabase, quote: MintQuote) {
+        let payment_amount = quote.amount.clone().expect("quote amount");
+        let payment_id = format!("payment-{}", quote.id);
+        let mut tx = db.begin_transaction().await.expect("begin transaction");
+        let mut quote = tx.add_mint_quote(quote).await.expect("add mint quote");
+        quote
+            .add_payment(payment_amount, payment_id, Some(0))
+            .expect("add payment");
+        tx.update_mint_quote(&mut quote)
+            .await
+            .expect("update mint quote");
+        tx.commit().await.expect("commit transaction");
+    }
+
+    #[tokio::test]
+    async fn get_events_from_db_batches_multiple_mint_quote_filters() {
+        let db: DynMintDatabase = Arc::new(
+            cdk_sqlite::mint::memory::empty()
+                .await
+                .expect("in-memory mint database"),
+        );
+        let first_quote_id = QuoteId::new_uuid();
+        let second_quote_id = QuoteId::new_uuid();
+        add_mint_quote(&db, paid_bolt11_quote(first_quote_id.clone(), 21)).await;
+        add_mint_quote(&db, paid_bolt11_quote(second_quote_id.clone(), 34)).await;
+
+        let spec = MintPubSubSpec {
+            db,
+            payment_processors: Arc::new(HashMap::new()),
+        };
+        let events = spec
+            .get_events_from_db(&[
+                NotificationId::MintQuoteBolt11(first_quote_id.clone()),
+                NotificationId::MintQuoteBolt11(second_quote_id.clone()),
+            ])
+            .await
+            .expect("get events");
+
+        let quote_ids = events
+            .into_iter()
+            .map(|event| match event.into_inner() {
+                NotificationPayload::MintQuoteBolt11Response(response) => response.quote,
+                payload => panic!("unexpected payload: {payload:?}"),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(quote_ids, vec![first_quote_id, second_quote_id]);
     }
 }

--- a/crates/cdk/src/mint/verification.rs
+++ b/crates/cdk/src/mint/verification.rs
@@ -76,6 +76,13 @@ impl Mint {
                         );
                         return Err(Error::InactiveKeyset);
                     }
+                    if keyset.is_expired() {
+                        tracing::debug!(
+                            "Transaction attempted with expired keyset in outputs: {}.",
+                            id
+                        );
+                        return Err(Error::ExpiredKeyset);
+                    }
                     keyset_units.insert(keyset.unit);
                 }
                 None => {
@@ -114,6 +121,13 @@ impl Mint {
         for id in &inputs_keyset_ids {
             match self.get_keyset_info(id) {
                 Some(keyset) => {
+                    if keyset.is_expired() {
+                        tracing::debug!(
+                            "Transaction attempted with expired keyset in inputs: {}.",
+                            id
+                        );
+                        return Err(Error::ExpiredKeyset);
+                    }
                     keyset_units.insert(keyset.unit);
                 }
                 None => {

--- a/crates/cdk/src/wallet/auth/auth_wallet.rs
+++ b/crates/cdk/src/wallet/auth/auth_wallet.rs
@@ -280,7 +280,17 @@ impl AuthWallet {
     pub async fn is_protected(&self, method: &ProtectedEndpoint) -> Option<AuthRequired> {
         let protected_endpoints = self.protected_endpoints.read().await;
 
-        protected_endpoints.get(method).copied()
+        protected_endpoints.get(method).copied().or_else(|| {
+            protected_endpoints
+                .iter()
+                .filter_map(|(endpoint, auth)| {
+                    endpoint
+                        .match_specificity(method)
+                        .map(|specificity| (specificity, *auth))
+                })
+                .max_by_key(|(specificity, _)| *specificity)
+                .map(|(_, auth)| auth)
+        })
     }
 
     /// Get Auth Token
@@ -469,5 +479,78 @@ impl AuthWallet {
         Ok(Amount::from(
             self.get_unspent_auth_proofs().await?.len() as u64
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use cdk_common::mint_url::MintUrl;
+
+    use super::*;
+    use crate::nuts::{Method, RoutePath};
+
+    async fn auth_wallet(
+        protected_endpoints: HashMap<ProtectedEndpoint, AuthRequired>,
+    ) -> AuthWallet {
+        let mint_url = MintUrl::from_str("https://test-mint.example.com")
+            .expect("test mint URL should be valid");
+        let localstore = Arc::new(
+            cdk_sqlite::wallet::memory::empty()
+                .await
+                .expect("in-memory wallet database should initialize"),
+        );
+        let metadata_cache = Arc::new(MintMetadataCache::new(mint_url.clone()));
+
+        AuthWallet::new(
+            mint_url,
+            None,
+            localstore,
+            metadata_cache,
+            protected_endpoints,
+            None,
+        )
+    }
+
+    #[tokio::test]
+    async fn is_protected_matches_wildcard_by_specificity() {
+        let request =
+            ProtectedEndpoint::new(Method::Post, RoutePath::MintQuote("bolt11".to_string()));
+        let exact =
+            ProtectedEndpoint::new(Method::Post, RoutePath::MintQuote("bolt11".to_string()));
+        let broad_wildcard =
+            ProtectedEndpoint::new(Method::Post, RoutePath::Wildcard("/v1/".to_string()));
+        let specific_wildcard = ProtectedEndpoint::new(
+            Method::Post,
+            RoutePath::Wildcard("/v1/mint/quote/".to_string()),
+        );
+        let different_method_wildcard = ProtectedEndpoint::new(
+            Method::Get,
+            RoutePath::Wildcard("/v1/mint/quote/".to_string()),
+        );
+
+        let wallet = auth_wallet(HashMap::from([
+            (broad_wildcard, AuthRequired::Clear),
+            (specific_wildcard, AuthRequired::Blind),
+            (different_method_wildcard, AuthRequired::Clear),
+        ]))
+        .await;
+
+        assert_eq!(
+            wallet.is_protected(&request).await,
+            Some(AuthRequired::Blind)
+        );
+
+        wallet
+            .protected_endpoints
+            .write()
+            .await
+            .insert(exact, AuthRequired::Clear);
+
+        assert_eq!(
+            wallet.is_protected(&request).await,
+            Some(AuthRequired::Clear)
+        );
     }
 }

--- a/crates/cdk/src/wallet/bip321.rs
+++ b/crates/cdk/src/wallet/bip321.rs
@@ -308,48 +308,61 @@ fn extract_payment_methods<'a>(
 
 impl fmt::Display for Bip321UriBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("bitcoin:")?;
+        let mut uri = String::from("BITCOIN:");
 
-        // On-chain address goes in the path
         if let Some(ref addr) = self.onchain_address {
-            f.write_str(addr)?;
+            uri.push_str(&uppercase_qr_address(addr));
         }
 
         let mut query_params = form_urlencoded::Serializer::new(String::new());
 
         if let Some(amount_sats) = self.amount_sats {
             let amount_btc = format_btc_amount_from_sats(amount_sats);
-            query_params.append_pair("amount", &amount_btc);
+            query_params.append_pair("AMOUNT", &amount_btc);
         }
 
         if let Some(ref label) = self.label {
-            query_params.append_pair("label", label);
+            query_params.append_pair("LABEL", &label.to_ascii_uppercase());
         }
 
         if let Some(ref message) = self.message {
-            query_params.append_pair("message", message);
+            query_params.append_pair("MESSAGE", &message.to_ascii_uppercase());
         }
 
         if let Some(ref bolt11) = self.bolt11_invoice {
-            query_params.append_pair("lightning", bolt11);
+            query_params.append_pair("LIGHTNING", &bolt11.to_ascii_uppercase());
         }
 
         if let Some(ref bolt12) = self.bolt12_offer {
-            query_params.append_pair("lno", bolt12);
+            query_params.append_pair("LNO", &bolt12.to_ascii_uppercase());
         }
 
         if let Some(ref creq) = self.cashu_request_str {
-            query_params.append_pair("creq", creq);
+            query_params.append_pair("CREQ", &creq.to_ascii_uppercase());
         }
 
         let query_string = query_params.finish();
         if !query_string.is_empty() {
-            f.write_str("?")?;
-            f.write_str(&query_string)?;
+            uri.push('?');
+            uri.push_str(&query_string);
         }
 
-        Ok(())
+        f.write_str(&uri)
     }
+}
+
+fn uppercase_qr_address(address: &str) -> String {
+    if is_qr_friendly_segwit_address(address) {
+        return address.to_ascii_uppercase();
+    }
+
+    address.to_string()
+}
+
+fn is_qr_friendly_segwit_address(address: &str) -> bool {
+    let lowercase = address.to_ascii_lowercase();
+
+    lowercase.starts_with("bc1") || lowercase.starts_with("tb1") || lowercase.starts_with("bcrt1")
 }
 
 /// Format satoshis to BTC string without trailing zeros, per BIP 21.
@@ -377,8 +390,8 @@ mod tests {
     }
 
     fn assert_has_creq(uri: &str) {
-        assert!(uri.starts_with("bitcoin:?") || uri.starts_with("bitcoin:bc1"));
-        assert!(uri.contains("creq="));
+        assert!(uri.starts_with("BITCOIN:?") || uri.starts_with("BITCOIN:BC1"));
+        assert!(uri.contains("CREQ="));
     }
 
     fn assert_demo_cashu(parsed: &ParsedPaymentInstruction) {
@@ -410,16 +423,16 @@ mod tests {
             .with_message("Coffee payment".to_string())
             .to_string();
 
-        assert!(uri.starts_with(&format!("bitcoin:{addr}?")));
-        assert!(uri.contains("creq="));
-        assert!(uri.contains("amount=0.001"));
-        assert!(uri.contains("message=Coffee+payment"));
+        assert!(uri.starts_with(&format!("BITCOIN:{}?", addr.to_ascii_uppercase())));
+        assert!(uri.contains("CREQ="));
+        assert!(uri.contains("AMOUNT=0.001"));
+        assert!(uri.contains("MESSAGE=COFFEE+PAYMENT"));
     }
 
     #[test]
     fn test_bip321_uri_empty_params() {
         let uri = Bip321UriBuilder::new().to_string();
-        assert_eq!(uri, "bitcoin:");
+        assert_eq!(uri, "BITCOIN:");
     }
 
     #[test]
@@ -436,7 +449,7 @@ mod tests {
             .with_label("a=b&c=d".to_string())
             .with_message("hello world".to_string())
             .to_string();
-        assert_eq!(uri, "bitcoin:?label=a%3Db%26c%3Dd&message=hello+world");
+        assert_eq!(uri, "BITCOIN:?LABEL=A%3DB%26C%3DD&MESSAGE=HELLO+WORLD");
     }
 
     #[tokio::test]
@@ -449,19 +462,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_bip321_uri_with_cashu() {
-        let uri = format!("bitcoin:?creq={TEST_CREQ}");
+        let uri = format!("BITCOIN:?CREQ={TEST_CREQ}");
         let parsed = parse_payment_instruction(&uri, bitcoin::Network::Bitcoin)
             .await
-            .expect("should parse bitcoin: URI with creq");
+            .expect("should parse BITCOIN: URI with CREQ");
         assert_demo_cashu(&parsed);
     }
 
     #[tokio::test]
     async fn test_parse_bip321_uri_with_cashu_and_amount() {
-        let uri = format!("bitcoin:?creq={TEST_CREQ}&amount=0.00001");
+        let uri = format!("BITCOIN:?CREQ={TEST_CREQ}&AMOUNT=0.00001");
         let parsed = parse_payment_instruction(&uri, bitcoin::Network::Bitcoin)
             .await
-            .expect("should parse bitcoin: URI with creq and amount");
+            .expect("should parse BITCOIN: URI with CREQ and AMOUNT");
 
         assert_eq!(parsed.cashu_requests.len(), 1);
         assert_eq!(parsed.amount_msats, Some(1_000_000));
@@ -521,9 +534,9 @@ mod tests {
             .with_onchain_address("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq".to_string())
             .with_amount_sats(100_000)
             .to_string();
-        assert!(uri.contains("creq="));
-        assert!(uri.contains("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"));
-        assert!(uri.contains("amount=0.001"));
+        assert!(uri.contains("CREQ="));
+        assert!(uri.contains("BC1QAR0SRRR7XFKVY5L643LYDNW9RE59GTZZWF5MDQ"));
+        assert!(uri.contains("AMOUNT=0.001"));
     }
 
     #[tokio::test]
@@ -544,10 +557,10 @@ mod tests {
         let uri = Bip321UriBuilder::new()
             .with_bolt12_offer(offer.to_string())
             .to_string();
-        assert!(uri.starts_with("bitcoin:?"));
-        assert!(uri.contains(&format!("lno={offer}")));
-        assert!(!uri.contains("creq="));
-        assert!(!uri.contains("lightning="));
+        assert!(uri.starts_with("BITCOIN:?"));
+        assert!(uri.contains(&format!("LNO={}", offer.to_ascii_uppercase())));
+        assert!(!uri.contains("CREQ="));
+        assert!(!uri.contains("LIGHTNING="));
     }
 
     #[test]
@@ -555,7 +568,37 @@ mod tests {
         let uri = Bip321UriBuilder::new()
             .with_label("Donation".to_string())
             .to_string();
-        assert!(uri.contains("label=Donation"));
+        assert!(uri.contains("LABEL=DONATION"));
+    }
+
+    #[test]
+    fn test_base58_address_preserved() {
+        let addr = "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W";
+        let uri = Bip321UriBuilder::new()
+            .with_onchain_address(addr.to_string())
+            .to_string();
+
+        assert_eq!(uri, format!("BITCOIN:{addr}"));
+    }
+
+    #[test]
+    fn test_testnet_segwit_address_is_uppercased() {
+        let addr = "tb1qghfhmd4zh7ncpmxl3qzhmq566jk8ckq4gafnmg";
+        let uri = Bip321UriBuilder::new()
+            .with_onchain_address(addr.to_string())
+            .to_string();
+
+        assert_eq!(uri, format!("BITCOIN:{}", addr.to_ascii_uppercase()));
+    }
+
+    #[test]
+    fn test_regtest_segwit_address_is_uppercased() {
+        let addr = "bcrt1qxlvaw9k0v4m4u6sz5s4z7qjv3f4x0n8xk5m9z2";
+        let uri = Bip321UriBuilder::new()
+            .with_onchain_address(addr.to_string())
+            .to_string();
+
+        assert_eq!(uri, format!("BITCOIN:{}", addr.to_ascii_uppercase()));
     }
 
     #[tokio::test]

--- a/crates/cdk/src/wallet/mint_metadata_cache.rs
+++ b/crates/cdk/src/wallet/mint_metadata_cache.rs
@@ -224,7 +224,6 @@ impl MintMetadataCache {
     /// // Force refresh from mint (ignores cache)
     /// let fresh = cache.load_from_mint(&storage, &client).await?;
     /// ```
-    #[inline(always)]
     pub async fn load_from_mint(
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
@@ -245,27 +244,99 @@ impl MintMetadataCache {
             return Ok(current_metadata);
         }
 
-        // Load keys from database before fetching from HTTP
-        // This prevents re-fetching keys we already have and avoids duplicate insertions
-        if let Some(keysets) = storage.get_mint_keysets(self.mint_url.clone()).await? {
-            let mut updated_metadata = (*self.metadata.load().clone()).clone();
-            for keyset_info in keysets {
-                if let Some(keys) = storage.get_keys(&keyset_info.id).await? {
-                    tracing::trace!("Loaded keys for keyset {} from database", keyset_info.id);
-                    updated_metadata.keys.insert(keyset_info.id, Arc::new(keys));
-                }
-            }
-            // Update cache with database keys before HTTP fetch
-            self.metadata.store(Arc::new(updated_metadata));
+        if !current_metadata.status.is_populated {
+            let _ = self.load_from_db(storage).await;
         }
 
         // Perform the fetch
+        // Note: keys already in cache (e.g. from load_from_db at boot) are
+        // skipped by fetch_from_http's Vacant entry check.
         let metadata = self.fetch_from_http(Some(client), None).await?;
 
         // Persist to database
         self.database_sync(storage.clone(), metadata.clone()).await;
 
         Ok(metadata)
+    }
+
+    /// Load metadata from database and update cache
+    ///
+    /// Populates the in-memory cache from persisted database data without
+    /// making any HTTP requests. Useful for offline scenarios or fast startup
+    /// when the wallet can work with previously-fetched data.
+    ///
+    /// Uses a mutex to ensure only one load runs at a time. If multiple
+    /// callers request a load simultaneously, only one reads from the database
+    /// while others wait for the lock, then return the updated cache.
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - Database to load metadata from
+    ///
+    /// # Returns
+    ///
+    /// Metadata loaded from the database
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Load from database (no HTTP)
+    /// let metadata = cache.load_from_db(&storage).await?;
+    /// ```
+    async fn load_from_db(
+        &self,
+        storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
+    ) -> Result<Arc<MintMetadata>, Error> {
+        let mut new_metadata = (*self.metadata.load().clone()).clone();
+
+        // Load mint info
+        if let Some(mint_info) = storage.get_mint(self.mint_url.clone()).await? {
+            new_metadata.mint_info = mint_info;
+        }
+
+        // Load keysets and their keys
+        if let Some(keysets) = storage.get_mint_keysets(self.mint_url.clone()).await? {
+            new_metadata.active_keysets.clear();
+            for keyset_info in keysets {
+                let keyset_arc = Arc::new(keyset_info.clone());
+                new_metadata
+                    .keysets
+                    .insert(keyset_info.id, keyset_arc.clone());
+
+                if keyset_info.active {
+                    new_metadata.active_keysets.push(keyset_arc);
+                }
+
+                if let Some(keys) = storage.get_keys(&keyset_info.id).await? {
+                    tracing::trace!("Loaded keys for keyset {} from database", keyset_info.id);
+                    new_metadata.keys.insert(keyset_info.id, Arc::new(keys));
+                }
+            }
+        }
+
+        // Only mark as populated if we actually loaded keysets
+        new_metadata.status.is_populated = !new_metadata.keysets.is_empty();
+        new_metadata.status.updated_at = Instant::now();
+        new_metadata.status.version += 1;
+
+        tracing::info!(
+            "Loaded cache from database for {} with {} keysets (version {})",
+            self.mint_url,
+            new_metadata.keysets.len(),
+            new_metadata.status.version
+        );
+
+        // Atomically update cache
+        let metadata_arc = Arc::new(new_metadata);
+        self.metadata.store(metadata_arc.clone());
+
+        // Mark DB as synced (data came from DB, no need to write back)
+        let storage_id = Self::arc_pointer_id(storage);
+        self.db_sync_versions
+            .write()
+            .insert(storage_id, metadata_arc.status.version);
+
+        Ok(metadata_arc)
     }
 
     /// Load metadata from cache or fetch if not available
@@ -292,7 +363,6 @@ impl MintMetadataCache {
     /// // Use cached data if available, fetch if not
     /// let metadata = cache.load(&storage, &client).await?;
     /// ```
-    #[inline(always)]
     pub async fn load(
         &self,
         storage: &Arc<dyn WalletDatabase<database::Error> + Send + Sync>,
@@ -324,7 +394,14 @@ impl MintMetadataCache {
             return Ok(cached_metadata);
         }
 
-        // Cache not populated - fetch from mint
+        // Try loading from database first (avoids HTTP if data is persisted)
+        if let Ok(metadata) = self.load_from_db(storage).await {
+            if metadata.status.is_populated {
+                return Ok(metadata);
+            }
+        }
+
+        // Database had no data - fetch from mint
         self.load_from_mint(storage, client).await
     }
 
@@ -380,23 +457,6 @@ impl MintMetadataCache {
                 "Auth cache was updated while waiting for fetch lock, returning cached data"
             );
             return Ok(current_metadata);
-        }
-
-        // Load keys from database before fetching from HTTP
-        // This prevents re-fetching keys we already have and avoids duplicate insertions
-        if let Some(keysets) = storage.get_mint_keysets(self.mint_url.clone()).await? {
-            let mut updated_metadata = (*self.metadata.load().clone()).clone();
-            for keyset_info in keysets {
-                if let Some(keys) = storage.get_keys(&keyset_info.id).await? {
-                    tracing::trace!(
-                        "Loaded keys for keyset {} from database (auth)",
-                        keyset_info.id
-                    );
-                    updated_metadata.keys.insert(keyset_info.id, Arc::new(keys));
-                }
-            }
-            // Update cache with database keys before HTTP fetch
-            self.metadata.store(Arc::new(updated_metadata));
         }
 
         // Auth data not in cache - fetch from mint
@@ -574,6 +634,7 @@ impl MintMetadataCache {
         );
 
         // Fetch keys for each keyset
+        new_metadata.active_keysets.clear();
         for keyset_info in keysets_to_fetch {
             let keyset_arc = Arc::new(keyset_info.clone());
             new_metadata

--- a/meetings/2026-05-06-agenda.md
+++ b/meetings/2026-05-06-agenda.md
@@ -5,34 +5,58 @@ May 06 2026 15:00 UTC
 Meeting Link: https://meet.fulmo.org/cdk-dev
 
 ## Merged
-- [#1937](https://github.com/cashubtc/cdk/pull/1937) - feat: uppercase bip321 string
-- [#1941](https://github.com/cashubtc/cdk/pull/1941) - fix: create melt quote kind index on melt table
-- [#1951](https://github.com/cashubtc/cdk/pull/1951) - Migrate Swift tests from XCTest to Swift Testing
+- [@asmogo](https://github.com/asmogo) - [#1941](https://github.com/cashubtc/cdk/pull/1941) - fix: create melt quote kind index on melt table
+- [@crodas](https://github.com/crodas) - [#1951](https://github.com/cashubtc/cdk/pull/1951) - Migrate Swift tests from XCTest to Swift Testing
+- [@Forte11Cuba](https://github.com/Forte11Cuba) - [#1890](https://github.com/cashubtc/cdk/pull/1890) - Feat/prepare melt token
+- [@Forte11Cuba](https://github.com/Forte11Cuba) - [#1920](https://github.com/cashubtc/cdk/pull/1920) - fix(wallet): surface HTTP status code in Async transport
+- [@thesimplekid](https://github.com/thesimplekid) - [#1885](https://github.com/cashubtc/cdk/pull/1885) - Async melt streams
+- [@thesimplekid](https://github.com/thesimplekid) - [#1922](https://github.com/cashubtc/cdk/pull/1922) - test: mutation testing
+- [@thesimplekid](https://github.com/thesimplekid) - [#1928](https://github.com/cashubtc/cdk/pull/1928) - chore: bump rust stable to 1.95.0
+- [@thesimplekid](https://github.com/thesimplekid) - [#1929](https://github.com/cashubtc/cdk/pull/1929) - fix(wallet): recover failed melt confirms via saga state
+- [@thesimplekid](https://github.com/thesimplekid) - [#1930](https://github.com/cashubtc/cdk/pull/1930) - fix(cli): consistently and scope balance by unit
+- [@thesimplekid](https://github.com/thesimplekid) - [#1937](https://github.com/cashubtc/cdk/pull/1937) - feat: uppercase bip321 string
 
 ## New
 
 ### Issues
 
-- [#1950](https://github.com/cashubtc/cdk/issues/1950) - 🧬 Weekly Mutation Testing Report - 2026-05-01
+- [@4xvgal](https://github.com/4xvgal) - [#1926](https://github.com/cashubtc/cdk/issues/1926) - feat: auto zero fee_reserve for direct peer channels
+- [@app/github-actions](https://github.com/apps/github-actions) - [#1935](https://github.com/cashubtc/cdk/issues/1935) - 🧬 Weekly Mutation Testing Report - 2026-04-24
+- [@app/github-actions](https://github.com/apps/github-actions) - [#1940](https://github.com/cashubtc/cdk/issues/1940) - Update Rust to 1.95.0
+- [@app/github-actions](https://github.com/apps/github-actions) - [#1950](https://github.com/cashubtc/cdk/issues/1950) - 🧬 Weekly Mutation Testing Report - 2026-05-01
+- [@gudnuf](https://github.com/gudnuf) - [#1933](https://github.com/cashubtc/cdk/issues/1933) - get_blind_signatures_for_quote returns non-deterministic order
+- [@gudnuf](https://github.com/gudnuf) - [#1945](https://github.com/cashubtc/cdk/issues/1945) - `rotate_keyset` does not validate that expiry is in the future
+- [@thesimplekid](https://github.com/thesimplekid) - [#1927](https://github.com/cashubtc/cdk/issues/1927) - Wallet handle receive when offline
+- [@thesimplekid](https://github.com/thesimplekid) - [#1934](https://github.com/cashubtc/cdk/issues/1934) - Uppercase the bip321 ln invoice for better qr encoding
+- [@thesimplekid](https://github.com/thesimplekid) - [#1938](https://github.com/cashubtc/cdk/issues/1938) - Review the wallet's metadata cache for offline use
+- [@ye0man](https://github.com/ye0man) - [#1943](https://github.com/cashubtc/cdk/issues/1943) - feat: add NUT-29 batch minting error codes
 
 ### PRs
 
-- [#1952](https://github.com/cashubtc/cdk/pull/1952) - feat: add cdk review for agents
-- [#1949](https://github.com/cashubtc/cdk/pull/1949) - feat(mintd): allow multiple lightning backends per currency unit
-- [#1948](https://github.com/cashubtc/cdk/pull/1948) - Fix Prometheus in-flight metric handling
-- [#1954](https://github.com/cashubtc/cdk/pull/1954) -  Migrate INTEGER/BIGINT columns storing u64 values to TEXT
+- [@asmogo](https://github.com/asmogo) - [#1942](https://github.com/cashubtc/cdk/pull/1942) - fix: melt lookup kind unique index
+- [@asmogo](https://github.com/asmogo) - [#1948](https://github.com/cashubtc/cdk/pull/1948) - Fix Prometheus in-flight metric handling
+- [@crodas](https://github.com/crodas) - [#1954](https://github.com/cashubtc/cdk/pull/1954) - Migrate INTEGER/BIGINT columns storing u64 values to TEXT
+- [@GEET3001](https://github.com/GEET3001) - [#1931](https://github.com/cashubtc/cdk/pull/1931) - feat(wallet): add offline ecash receiving with DLEQ verification
+- [@GEET3001](https://github.com/GEET3001) - [#1936](https://github.com/cashubtc/cdk/pull/1936) - feat(cdk-axum): support redis-cluster for caching
+- [@Micah-Shallom](https://github.com/Micah-Shallom) - [#1949](https://github.com/cashubtc/cdk/pull/1949) - feat(mintd): allow multiple lightning backends per currency unit
+- [@thesimplekid](https://github.com/thesimplekid) - [#1952](https://github.com/cashubtc/cdk/pull/1952) - feat: add cdk review for agents
 
 ## Recently Active
 
-- [#1946](https://github.com/cashubtc/cdk/pull/1946) - feat: enforce keyset expiry
-- [#1944](https://github.com/cashubtc/cdk/pull/1944) - feat(mint): add NUT-29 batch minting error codes
-- [#1925](https://github.com/cashubtc/cdk/pull/1925) - feat: add preferred_mints to payment requests
-- [#1769](https://github.com/cashubtc/cdk/pull/1769) - feat(wallet): default-on token-bucket rate limiting
-- [#1666](https://github.com/cashubtc/cdk/pull/1666) - feat: NUT-CTF conditional tokens for prediction markets
-- [#1915](https://github.com/cashubtc/cdk/pull/1915) - fix: remove state from MintQuoteCustomResponse and update default extra
-- [#1939](https://github.com/cashubtc/cdk/pull/1939) - Add Kotlin bindings build config and CI publish workflow
-- [#1932](https://github.com/cashubtc/cdk/pull/1932) - NUT-XX: Mint Quote Lookup by Public Key - Wallet Side
-- [#1870](https://github.com/cashubtc/cdk/pull/1870) - Onchain bdk
+- [@a1denvalu3](https://github.com/a1denvalu3) - [#1925](https://github.com/cashubtc/cdk/pull/1925) - feat: add preferred_mints to payment requests
+- [@asmogo](https://github.com/asmogo) - [#1915](https://github.com/cashubtc/cdk/pull/1915) - fix: remove state from MintQuoteCustomResponse and update default extra
+- [@crodas](https://github.com/crodas) - [#1665](https://github.com/cashubtc/cdk/pull/1665) - Add WASM/wasm-bindgen support to cdk-ffi
+- [@crodas](https://github.com/crodas) - [#1939](https://github.com/cashubtc/cdk/pull/1939) - Add Kotlin bindings build config and CI publish workflow
+- [@Forte11Cuba](https://github.com/Forte11Cuba) - [#1923](https://github.com/cashubtc/cdk/pull/1923) - feat(wallet): add RestoreOptions to tune Wallet::restore batching
+- [@Forte11Cuba](https://github.com/Forte11Cuba) - [#1944](https://github.com/cashubtc/cdk/pull/1944) - feat(mint): add NUT-29 batch minting error codes
+- [@gudnuf](https://github.com/gudnuf) - [#1946](https://github.com/cashubtc/cdk/pull/1946) - feat: enforce keyset expiry
+- [@joemphilips](https://github.com/joemphilips) - [#1666](https://github.com/cashubtc/cdk/pull/1666) - feat: NUT-CTF conditional tokens for prediction markets
+- [@lescuer97](https://github.com/lescuer97) - [#1608](https://github.com/cashubtc/cdk/pull/1608) - Add bitreq
+- [@Micah-Shallom](https://github.com/Micah-Shallom) - [#1769](https://github.com/cashubtc/cdk/pull/1769) - feat(wallet): default-on token-bucket rate limiting
+- [@TheMhv](https://github.com/TheMhv) - [#1834](https://github.com/cashubtc/cdk/pull/1834) - NUT-XX: Mint Quote Lookup by Public Key
+- [@TheMhv](https://github.com/TheMhv) - [#1932](https://github.com/cashubtc/cdk/pull/1932) - NUT-XX: Mint Quote Lookup by Public Key - Wallet Side
+- [@thesimplekid](https://github.com/thesimplekid) - [#1864](https://github.com/cashubtc/cdk/pull/1864) - chore: add apache license
+- [@thesimplekid](https://github.com/thesimplekid) - [#1870](https://github.com/cashubtc/cdk/pull/1870) - Onchain bdk
 
 ## Merged NUTS
 

--- a/meetings/2026-05-06-agenda.md
+++ b/meetings/2026-05-06-agenda.md
@@ -1,0 +1,47 @@
+# CDK Development Meeting
+
+May 06 2026 15:00 UTC
+
+Meeting Link: https://meet.fulmo.org/cdk-dev
+
+## Merged
+- [#1937](https://github.com/cashubtc/cdk/pull/1937) - feat: uppercase bip321 string
+- [#1941](https://github.com/cashubtc/cdk/pull/1941) - fix: create melt quote kind index on melt table
+- [#1951](https://github.com/cashubtc/cdk/pull/1951) - Migrate Swift tests from XCTest to Swift Testing
+
+## New
+
+### Issues
+
+- [#1950](https://github.com/cashubtc/cdk/issues/1950) - 🧬 Weekly Mutation Testing Report - 2026-05-01
+
+### PRs
+
+- [#1952](https://github.com/cashubtc/cdk/pull/1952) - feat: add cdk review for agents
+- [#1949](https://github.com/cashubtc/cdk/pull/1949) - feat(mintd): allow multiple lightning backends per currency unit
+- [#1948](https://github.com/cashubtc/cdk/pull/1948) - Fix Prometheus in-flight metric handling
+- [#1954](https://github.com/cashubtc/cdk/pull/1954) -  Migrate INTEGER/BIGINT columns storing u64 values to TEXT
+
+## Recently Active
+
+- [#1946](https://github.com/cashubtc/cdk/pull/1946) - feat: enforce keyset expiry
+- [#1944](https://github.com/cashubtc/cdk/pull/1944) - feat(mint): add NUT-29 batch minting error codes
+- [#1925](https://github.com/cashubtc/cdk/pull/1925) - feat: add preferred_mints to payment requests
+- [#1769](https://github.com/cashubtc/cdk/pull/1769) - feat(wallet): default-on token-bucket rate limiting
+- [#1666](https://github.com/cashubtc/cdk/pull/1666) - feat: NUT-CTF conditional tokens for prediction markets
+- [#1915](https://github.com/cashubtc/cdk/pull/1915) - fix: remove state from MintQuoteCustomResponse and update default extra
+- [#1939](https://github.com/cashubtc/cdk/pull/1939) - Add Kotlin bindings build config and CI publish workflow
+- [#1932](https://github.com/cashubtc/cdk/pull/1932) - NUT-XX: Mint Quote Lookup by Public Key - Wallet Side
+- [#1870](https://github.com/cashubtc/cdk/pull/1870) - Onchain bdk
+
+## Merged NUTS
+
+- None
+
+## Backports
+
+- None
+
+## Discussion
+
+- None

--- a/meetings/2026-05-13-agenda.md
+++ b/meetings/2026-05-13-agenda.md
@@ -1,0 +1,73 @@
+# CDK Development Meeting
+
+May 13 2026 15:00 UTC
+
+Meeting Link: https://meet.fulmo.org/cdk-dev
+
+## Stand-up / Per-person Updates
+
+### thesimplekid
+- **Merged:**
+  - [#1952](https://github.com/cashubtc/cdk/pull/1952) - feat: add cdk review for agents
+  - [#1808](https://github.com/cashubtc/cdk/pull/1808) - fix: replace blocking Condvar pool with async Semaphore
+- **New PRs:**
+  - [#1964](https://github.com/cashubtc/cdk/pull/1964) - fix: batch mint quote subscription snapshots
+  - [#1963](https://github.com/cashubtc/cdk/pull/1963) - doc: update agent review
+- **Recently Active:**
+  - [#1864](https://github.com/cashubtc/cdk/pull/1864) - chore: add apache license
+  - [#1870](https://github.com/cashubtc/cdk/pull/1870) - Onchain bdk
+
+### crodas
+- **Merged:**
+  - [#1957](https://github.com/cashubtc/cdk/pull/1957) - Add load_from_db to MintMetadataCache
+- **Recently Active:**
+  - [#1954](https://github.com/cashubtc/cdk/pull/1954) - Migrate INTEGER/BIGINT columns storing u64 values to TEXT
+
+### a1denvalu3
+- **New PRs:**
+  - [#1961](https://github.com/cashubtc/cdk/pull/1961) - fix(mint): preserve change promises order in paid melt quotes
+
+### asmogo
+- **New PRs:**
+  - [#1962](https://github.com/cashubtc/cdk/pull/1962) - check and merge config from toml and env
+- **Recently Active:**
+  - [#1948](https://github.com/cashubtc/cdk/pull/1948) - Fix Prometheus in-flight metric handling
+
+### TheMhv
+- **New PRs:**
+  - [#1958](https://github.com/cashubtc/cdk/pull/1958) - (WIP) Fix: Ensure wallet's metadata cache for offline use
+
+### Micah-Shallom
+- **Recently Active:**
+  - [#1949](https://github.com/cashubtc/cdk/pull/1949) - feat(mintd): allow multiple lightning backends per currency unit
+  - [#1769](https://github.com/cashubtc/cdk/pull/1769) - feat(wallet): default-on token-bucket rate limiting
+
+### Forte11Cuba
+- **Recently Active:**
+  - [#1944](https://github.com/cashubtc/cdk/pull/1944) - feat(mint): add NUT-29 batch minting error codes
+  - [#1923](https://github.com/cashubtc/cdk/pull/1923) - feat(wallet): add RestoreOptions to tune Wallet::restore batching
+
+### GEET3001
+- **Recently Active:**
+  - [#1936](https://github.com/cashubtc/cdk/pull/1936) - feat(cdk-axum): support redis-cluster for caching
+  - [#1931](https://github.com/cashubtc/cdk/pull/1931) - feat(wallet): add offline ecash receiving with DLEQ verification
+
+### joemphilips
+- **Recently Active:**
+  - [#1666](https://github.com/cashubtc/cdk/pull/1666) - feat: NUT-CTF conditional tokens for prediction markets
+
+### gudnuf
+- **Merged NUTS:**
+  - [#367](https://github.com/cashubtc/nuts/pull/367) - Add error code 12003: Keyset has expired
+
+### KvngMikey
+- **Merged NUTS:**
+  - [#366](https://github.com/cashubtc/nuts/pull/366) - feat: add NUT-29 batch minting error codes
+
+### github-actions
+- **New Issues:**
+  - [#1956](https://github.com/cashubtc/cdk/issues/1956) - 🧬 Weekly Mutation Testing Report - 2026-05-08
+
+## Discussion
+
+- None


### PR DESCRIPTION
## Summary

Enforce `final_expiry` on keysets so ecash from expired keysets is completely unusable — cannot be swapped, minted into, melted, or restored. Closes the enforcement half of #1895 (the "allow starting without active keysets" idea was dropped per the issue discussion — keysets stay `active: true` for backward compat with expiry-unaware wallets).

**Design:** Lazy expiry checks at every operation site. Expired keysets keep `active: true` and stay listed in `/v1/keys` and `/v1/keysets` responses. Wallets that don't know about `final_expiry` discover expiry at use time via the new `ExpiredKeyset` error. The mint remains globally NUT-02 compliant even when all keysets across all units have expired (intentional shutdown signal — operator's responsibility).

## What changed

- New `Error::ExpiredKeyset` and `ErrorCode::KeysetExpired` (12003 — flagged with TODO to upstream to cashubtc/nuts `error_codes.md`)
- `MintKeySetInfo::is_expired()` and `SignatoryKeySet::is_expired()` helpers — strict `<` against `unix_time()`
- `verify_inputs_keyset()` and `verify_outputs_keyset()` reject expired (gates swap/mint/melt)
- `DbSignatory::blind_sign()` rejects expired (defense-in-depth, also gates the NUT-22 auth-mint path)
- `restore()` (NUT-09) skips expired-keyset signatures with `continue`
- `MintBuilder` won't auto-replace expired keysets — neither when active is expired nor when all keysets for a unit are expired (logs `tracing::warn`)
- `init_keysets()` won't reactivate expired keysets on signatory startup

## Tests

- 10 boundary-condition tests for `is_expired()` (None / far future / now / 1s ago / 0) on both helper types
- `verify_inputs_keyset_rejects_expired_keyset` and `verify_outputs_keyset_rejects_expired_keyset` (mint mod tests)
- `blind_sign_rejects_expired_keyset` (signatory tests)
- `test_builder_does_not_replace_all_expired_keysets` (integration test — also transitively exercises `init_keysets` skip)

`restore()` skip and `init_keysets` skip are tested transitively via the builder integration test, matching the project's existing convention for `InactiveKeyset` (no direct unit tests there either).

## Test plan

- [ ] `cargo test -p cdk-common --lib` — 80 passed (5 new is_expired)
- [ ] `cargo test -p cdk-signatory --lib` — 10 passed (5 is_expired + 1 blind_sign)
- [ ] `cargo test -p cdk --lib` — 369+ passed (verify_inputs + verify_outputs)
- [ ] `cargo test -p cdk-integration-tests --test mint test_builder_does_not_replace_all_expired_keysets` — passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --check` — clean

## Notes / out of scope

- **Quote-lifecycle race** (mint quote created pre-expiry, paid post-expiry → fails at redeem): per #1895 discussion this is a wallet concern. Mint correctly rejects.
- **Default-expiry config + auto-rotate** (suggested in #1895): future PR.